### PR TITLE
Development

### DIFF
--- a/.habitat/docker-compose.yml
+++ b/.habitat/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - ./docker/nginx/conf.d:/etc/nginx/conf.d:ro
+      - ../docker/nginx/conf.d:/etc/nginx/conf.d:ro
       - /etc/letsencrypt:/etc/letsencrypt:ro
       - /var/www/letsencrypt:/var/www/letsencrypt:ro
 

--- a/.habitat/docker-compose.yml
+++ b/.habitat/docker-compose.yml
@@ -53,3 +53,5 @@ services:
 
 volumes:
   mongo-data:
+    external: true
+    name: sequenced_mongo-data

--- a/.habitat/docker-compose.yml
+++ b/.habitat/docker-compose.yml
@@ -14,20 +14,10 @@ services:
     build:
       context: ..
       dockerfile: packages/api/Dockerfile
-    container_name: api
     image: tidaltask/api
     platform: linux/amd64
-    environment:
-      APP_URL: ${APP_URL}
-      SESSION_SECRET: ${SESSION_SECRET}
-      DATABASE_URL: ${DATABASE_URL}
-      PORT: ${PORT}
-      RESEND_API_KEY: ${RESEND_API_KEY}
-      RESEND_AUDIENCE_ID: ${RESEND_AUDIENCE_ID}
-      FRONTEND_URL: ${FRONTEND_URL}
-      RESET_FROM_EMAIL: ${RESET_FROM_EMAIL}
-      WELCOME_FROM_EMAIL: ${WELCOME_FROM_EMAIL}
-      WELCOME_EMAIL_SUBJECT: ${WELCOME_EMAIL_SUBJECT}
+    env_file:
+      - ../.env
     depends_on:
       - mongo
     restart: unless-stopped
@@ -38,7 +28,6 @@ services:
     build:
       context: ..
       dockerfile: packages/app/Dockerfile
-    container_name: frontend
     image: tidaltask/frontend
     platform: linux/amd64
     depends_on:

--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -19,6 +19,18 @@
 
   <link href="/site.webmanifest" rel="manifest">
 
+  <!-- Apply theme synchronously to prevent flash -->
+  <script>
+    (function () {
+      try {
+        var saved = localStorage.getItem('tidaltask-theme');
+        var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        var isDark = saved === 'dark' || (saved !== 'light' && prefersDark);
+        if (isDark) document.documentElement.classList.add('dark');
+      } catch (_) {}
+    })();
+  </script>
+
 
   <!--  OpenGraph  -->
 

--- a/packages/app/src/components/calendar/ActiveCalendar.tsx
+++ b/packages/app/src/components/calendar/ActiveCalendar.tsx
@@ -1,5 +1,6 @@
 import { formatDate, generateWeek } from "@/utils/date";
 import CalendarItem from "./CalendarItem";
+import DateTimePicker from "@/pages/(Layout)/(TaskInfoMenu)/Shared/DateTimePicker";
 
 import { ChevronLeftIcon, ChevronRightIcon } from "@heroicons/react/16/solid";
 import { useApp } from "@/hooks/app";
@@ -24,15 +25,12 @@ export default function ActiveCalendar({ skeleton, searchSlot }: ActiveCalendarP
         <div className="p-1">
           <div className="flex items-center justify-between">
             <span className="text-lg font-semibold text-primary">This Week</span>
-            <div className="flex w-44 md:w-56 justify-end">
-              <div className="flex w-full items-center rounded-2xl border border-accent-blue/20 bg-accent-blue-50/60 px-2 py-1 shadow-inner dark:bg-(--accent-subtle)">
-                <input
-                  disabled
-                  value={formatDate(new Date())}
-                  type="date"
-                  className="w-full rounded-2xl border-none !bg-transparent text-center text-sm font-semibold text-muted focus:outline-hidden"
-                />
-              </div>
+            <div className="w-44 md:w-56">
+              <DateTimePicker
+                value={formatDate(new Date())}
+                onChange={() => {}}
+                dateOnly
+              />
             </div>
           </div>
           <div className="mt-4 flex items-center gap-2">
@@ -62,25 +60,6 @@ export default function ActiveCalendar({ skeleton, searchSlot }: ActiveCalendarP
 
   const dates = generateWeek(appData.activeDate || new Date(), 0);
 
-  function changeActiveMonth(e: React.ChangeEvent<HTMLInputElement>) {
-    let activeData = e.target.value.split("-");
-
-    let tempData = {
-      ...appData,
-    };
-
-    const tempYear = parseInt(activeData[0]);
-    const tempMonth = parseInt(activeData[1]) - 1;
-    const tempDay = parseInt(activeData[2]);
-
-    tempData.activeDate = new Date();
-    tempData.activeDate.setFullYear(tempYear);
-    tempData.activeDate.setMonth(tempMonth);
-    tempData.activeDate.setDate(tempDay);
-
-    setAppData(tempData);
-  }
-
   const checkDirection = () => {
     if (touchendX < touchstartX) return -1;
     if (touchendX > touchstartX) return 1;
@@ -104,15 +83,17 @@ export default function ActiveCalendar({ skeleton, searchSlot }: ActiveCalendarP
       <div className="p-1">
         <div className="flex items-center justify-between">
           <span className="text-lg font-semibold text-primary">This Week</span>
-          <div className="flex flex-row w-48 md:w-52">
-            <div className="flex justify-center w-full rounded-2xl border border-accent-blue/30 bg-white shadow-xs ring-1 ring-accent-blue/10 focus-within:ring-2 focus-within:ring-accent-blue/30 dark:bg-(--app-background) dark:border-accent-blue/40">
-              <input
-                type="date"
-                value={formatDate(appData.activeDate!)}
-                onChange={changeActiveMonth}
-                className="w-full h-full rounded-2xl border-none bg-transparent px-3 py-2 text-center text-sm font-semibold text-primary focus:outline-hidden"
-              />
-            </div>
+          <div className="w-48 md:w-52">
+            <DateTimePicker
+              value={formatDate(appData.activeDate!)}
+              onChange={(val) => {
+                const [y, m, d] = val.split("-").map(Number);
+                const next = new Date(appData.activeDate!);
+                next.setFullYear(y); next.setMonth(m - 1); next.setDate(d);
+                setAppData({ ...appData, activeDate: next });
+              }}
+              dateOnly
+            />
           </div>
         </div>
 

--- a/packages/app/src/components/calendar/ActiveCalendar.tsx
+++ b/packages/app/src/components/calendar/ActiveCalendar.tsx
@@ -21,7 +21,7 @@ export default function ActiveCalendar({ skeleton, searchSlot }: ActiveCalendarP
   if (skeleton) {
     return (
       <div className="w-full h-full">
-        <div className="rounded-3xl surface-card border p-4 shadow-sm">
+        <div className="p-1">
           <div className="flex items-center justify-between">
             <span className="text-lg font-semibold text-primary">This Week</span>
             <div className="flex w-44 md:w-56 justify-end">
@@ -30,7 +30,7 @@ export default function ActiveCalendar({ skeleton, searchSlot }: ActiveCalendarP
                   disabled
                   value={formatDate(new Date())}
                   type="date"
-                  className="w-full rounded-2xl border-none bg-transparent text-center text-sm font-semibold text-muted focus:outline-hidden"
+                  className="w-full rounded-2xl border-none !bg-transparent text-center text-sm font-semibold text-muted focus:outline-hidden"
                 />
               </div>
             </div>
@@ -101,7 +101,7 @@ export default function ActiveCalendar({ skeleton, searchSlot }: ActiveCalendarP
 
   return (
     <div className="w-full h-full">
-      <div className="rounded-3xl surface-card border p-4 shadow-sm">
+      <div className="p-1">
         <div className="flex items-center justify-between">
           <span className="text-lg font-semibold text-primary">This Week</span>
           <div className="flex flex-row w-48 md:w-52">
@@ -145,7 +145,7 @@ export default function ActiveCalendar({ skeleton, searchSlot }: ActiveCalendarP
         </div>
 
         {searchSlot && (
-          <div className="mt-3 pt-3 border-t border-(--surface-border)">
+          <div className="mt-3">
             {searchSlot}
           </div>
         )}

--- a/packages/app/src/components/calendar/ActiveCalendar.tsx
+++ b/packages/app/src/components/calendar/ActiveCalendar.tsx
@@ -1,15 +1,15 @@
 import { formatDate, generateWeek } from "@/utils/date";
 import CalendarItem from "./CalendarItem";
 
-import CalendarIcon from "@/assets/calendar.svg";
 import { ChevronLeftIcon, ChevronRightIcon } from "@heroicons/react/16/solid";
 import { useApp } from "@/hooks/app";
 
 type ActiveCalendarProps = {
   skeleton?: boolean;
+  searchSlot?: React.ReactNode;
 };
 
-export default function ActiveCalendar({ skeleton }: ActiveCalendarProps) {
+export default function ActiveCalendar({ skeleton, searchSlot }: ActiveCalendarProps) {
   const [appData, setAppData] = useApp();
 
   const shiftWeek = (direction: number) => {
@@ -23,14 +23,9 @@ export default function ActiveCalendar({ skeleton }: ActiveCalendarProps) {
       <div className="w-full h-full">
         <div className="rounded-3xl surface-card border p-4 shadow-sm">
           <div className="flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              <img src={CalendarIcon} className="h-6 w-6" />
-              <div className="flex flex-col">
-                <span className="text-lg font-semibold text-primary">This Week</span>
-              </div>
-            </div>
+            <span className="text-lg font-semibold text-primary">This Week</span>
             <div className="flex w-44 md:w-56 justify-end">
-              <div className="flex w-full items-center rounded-2xl border border-accent-blue/20 bg-accent-blue-50/60 px-2 py-1 shadow-inner dark:bg-[rgba(99,102,241,0.12)]">
+              <div className="flex w-full items-center rounded-2xl border border-accent-blue/20 bg-accent-blue-50/60 px-2 py-1 shadow-inner dark:bg-(--accent-subtle)">
                 <input
                   disabled
                   value={formatDate(new Date())}
@@ -40,22 +35,20 @@ export default function ActiveCalendar({ skeleton }: ActiveCalendarProps) {
               </div>
             </div>
           </div>
-          <div className="mt-4 flex flex-row items-center justify-center">
-            <div className="flex flex-row w-full h-full justify-evenly items-center">
-              <div className="hidden lg:flex">
-                <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-accent-blue-50 text-slate-400 shadow-inner dark:bg-[rgba(99,102,241,0.12)] dark:text-muted" aria-hidden>
-                  <ChevronLeftIcon className="w-6 h-6" />
-                </div>
+          <div className="mt-4 flex items-center gap-2">
+            <div className="hidden lg:flex shrink-0">
+              <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-accent-blue-50 text-slate-400 shadow-inner dark:bg-(--accent-subtle) dark:text-muted" aria-hidden>
+                <ChevronLeftIcon className="w-6 h-6" />
               </div>
-              <div className="w-full md:w-[90%] flex flex-row justify-between px-2 md:px-4">
-                {generateWeek(new Date(), 0).map((date, key) => (
-                  <CalendarItem date={date} key={key} />
-                ))}
-              </div>
-              <div className="hidden lg:flex">
-                <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-accent-blue-50 text-slate-400 shadow-inner dark:bg-[rgba(99,102,241,0.12)] dark:text-muted" aria-hidden>
-                  <ChevronRightIcon className="w-6 h-6" />
-                </div>
+            </div>
+            <div className="flex-1 flex flex-row gap-2">
+              {generateWeek(new Date(), 0).map((date, key) => (
+                <CalendarItem date={date} key={key} />
+              ))}
+            </div>
+            <div className="hidden lg:flex shrink-0">
+              <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-accent-blue-50 text-slate-400 shadow-inner dark:bg-(--accent-subtle) dark:text-muted" aria-hidden>
+                <ChevronRightIcon className="w-6 h-6" />
               </div>
             </div>
           </div>
@@ -91,7 +84,6 @@ export default function ActiveCalendar({ skeleton }: ActiveCalendarProps) {
   const checkDirection = () => {
     if (touchendX < touchstartX) return -1;
     if (touchendX > touchstartX) return 1;
-
     return 0;
   };
 
@@ -102,7 +94,6 @@ export default function ActiveCalendar({ skeleton }: ActiveCalendarProps) {
   const touchend = (e: React.TouchEvent) => {
     touchendX = e.changedTouches[0].screenX;
     const direction = checkDirection();
-
     if (direction !== 0) {
       shiftWeek(direction);
     }
@@ -112,14 +103,9 @@ export default function ActiveCalendar({ skeleton }: ActiveCalendarProps) {
     <div className="w-full h-full">
       <div className="rounded-3xl surface-card border p-4 shadow-sm">
         <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            {/* <img src={CalendarIcon} className="h-6 w-6" /> */}
-            <div className="flex flex-col justify-center">
-              <span className="text-lg font-semibold text-primary">This Week</span>
-            </div>
-          </div>
-          <div className="flex flex-row w-48 md:w-60">
-            <div className="flex justify-center w-full rounded-2xl border border-accent-blue/30 bg-white shadow-xs ring-1 ring-accent-blue/10 focus-within:ring-2 focus-within:ring-accent-blue/30 dark:bg-[rgba(15,23,42,0.85)] dark:border-accent-blue/40">
+          <span className="text-lg font-semibold text-primary">This Week</span>
+          <div className="flex flex-row w-48 md:w-52">
+            <div className="flex justify-center w-full rounded-2xl border border-accent-blue/30 bg-white shadow-xs ring-1 ring-accent-blue/10 focus-within:ring-2 focus-within:ring-accent-blue/30 dark:bg-(--app-background) dark:border-accent-blue/40">
               <input
                 type="date"
                 value={formatDate(appData.activeDate!)}
@@ -129,35 +115,40 @@ export default function ActiveCalendar({ skeleton }: ActiveCalendarProps) {
             </div>
           </div>
         </div>
-        <div className="mt-4 flex flex-row items-center justify-center">
-          <div className="flex flex-row w-full h-full justify-evenly items-center">
-            <div className="hidden lg:flex">
-              <button
-                className="flex h-10 w-10 items-center justify-center rounded-2xl bg-accent-blue-50 text-primary shadow-inner transition hover:bg-accent-blue-100 dark:bg-[rgba(99,102,241,0.12)]"
-                onClick={() => shiftWeek(-1)}
-              >
-                <ChevronLeftIcon className="w-6 h-6" />
-              </button>
-            </div>
-            <div
-              className="w-full md:w-[90%] flex flex-row justify-between px-2 md:px-4"
-              onTouchStart={touchstart}
-              onTouchEnd={touchend}
+
+        <div className="mt-4 flex items-center gap-2">
+          <div className="hidden lg:flex shrink-0">
+            <button
+              className="flex h-10 w-10 items-center justify-center rounded-2xl bg-accent-blue-50 text-primary shadow-inner transition hover:bg-accent-blue-100 dark:bg-(--accent-subtle)"
+              onClick={() => shiftWeek(-1)}
             >
-              {dates.map((date, key) => (
-                <CalendarItem date={date} key={key} />
-              ))}
-            </div>
-            <div className="hidden lg:flex">
-              <button
-                className="flex h-10 w-10 items-center justify-center rounded-2xl bg-accent-blue-50 text-primary shadow-inner transition hover:bg-accent-blue-100 dark:bg-[rgba(99,102,241,0.12)]"
-                onClick={() => shiftWeek(1)}
-              >
-                <ChevronRightIcon className="w-6 h-6" />
-              </button>
-            </div>
+              <ChevronLeftIcon className="w-6 h-6" />
+            </button>
+          </div>
+          <div
+            className="flex-1 flex flex-row gap-2"
+            onTouchStart={touchstart}
+            onTouchEnd={touchend}
+          >
+            {dates.map((date, key) => (
+              <CalendarItem date={date} key={key} />
+            ))}
+          </div>
+          <div className="hidden lg:flex shrink-0">
+            <button
+              className="flex h-10 w-10 items-center justify-center rounded-2xl bg-accent-blue-50 text-primary shadow-inner transition hover:bg-accent-blue-100 dark:bg-(--accent-subtle)"
+              onClick={() => shiftWeek(1)}
+            >
+              <ChevronRightIcon className="w-6 h-6" />
+            </button>
           </div>
         </div>
+
+        {searchSlot && (
+          <div className="mt-3 pt-3 border-t border-(--surface-border)">
+            {searchSlot}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/packages/app/src/components/calendar/CalendarItem.tsx
+++ b/packages/app/src/components/calendar/CalendarItem.tsx
@@ -1,47 +1,59 @@
 import { useApp } from "@/hooks/app";
 
-export default function CalendarItem({ skeleton, date }: {skeleton?: boolean, date: Date}) {
-
+export default function CalendarItem({ skeleton, date }: { skeleton?: boolean; date: Date }) {
   const [appData, setAppData] = useApp();
+
+  const changeDate = (date: Date) => {
+    setAppData({ ...appData, activeDate: date });
+  };
 
   if (skeleton) {
     return (
-      <div className="hover:bg-accent-white p-3 rounded-full w-10 h-10 flex justify-center text-center items-center">
-        <span className="text-lg">Today</span>
+      <div className="flex-1">
+        <div className="w-full flex flex-col items-center justify-center rounded-2xl py-3 px-2 opacity-40">
+          <span className="text-sm font-semibold text-slate-400">—</span>
+        </div>
       </div>
-    )
-  }
-
-  const changeDate = (date: Date) => {
-    let tempData = {
-      ...appData,
-      activeDate: date
-    };
-
-    tempData.activeDate = date;
-
-    setAppData(tempData);
+    );
   }
 
   const today = new Date();
   const isToday = today.toDateString() === date.toDateString();
   const isActive = appData.activeDate?.toDateString?.() === date.toDateString();
 
-  const baseClasses =
-    "p-3 rounded-full w-10 h-10 flex justify-center text-center items-center transition focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-accent-blue-600 text-primary";
-  const activeClasses =
-    "bg-accent-blue-700 text-white ring-2 ring-accent-blue-300 shadow-md";
-  const todayClasses =
-    "bg-accent-blue-50 text-accent-blue-700 border border-accent-blue/30 dark:bg-[rgba(99,102,241,0.18)] dark:text-primary";
+  const dayName = date.toLocaleDateString(undefined, { weekday: "short" });
+
+  let btnClasses = "w-full flex flex-col items-center justify-center rounded-2xl py-3 px-2 gap-0.5 transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-blue-600";
+  let textClasses = "text-sm font-semibold";
+  let numClasses = "text-lg font-semibold";
+
+  if (isActive) {
+    btnClasses += " bg-accent-blue-700 ring-2 ring-accent-blue-300 shadow-md";
+    textClasses += " text-white";
+    numClasses += " text-white";
+  } else if (isToday) {
+    btnClasses += " bg-accent-blue-50 border border-accent-blue/30 dark:bg-(--accent-subtle)";
+    textClasses += " text-accent-blue-600 dark:text-accent-blue-400";
+    numClasses += " text-accent-blue-600 dark:text-accent-blue-400";
+  } else {
+    btnClasses += " hover:bg-slate-100 dark:hover:bg-(--surface-raised)";
+    textClasses += " text-slate-700 dark:text-slate-200";
+    numClasses += " text-slate-700 dark:text-slate-200";
+  }
 
   return (
-    <button
-      type="button"
-      onClick={() => changeDate(date)}
-      aria-pressed={isActive}
-      className={`${baseClasses} ${isActive ? activeClasses : ""} ${!isActive && isToday ? todayClasses : ""}`}
-    >
-      <span className="text-lg font-semibold">{date.getDate()}</span>
-    </button>
-  )
+    <div className="flex-1">
+      <button
+        type="button"
+        onClick={() => changeDate(date)}
+        aria-pressed={isActive}
+        className={btnClasses}
+      >
+        {/* Desktop: day name (Mon, Tue…) */}
+        <span className={`max-md:hidden ${textClasses}`}>{dayName}</span>
+        {/* Mobile: date number */}
+        <span className={`md:hidden ${numClasses}`}>{date.getDate()}</span>
+      </button>
+    </div>
+  );
 }

--- a/packages/app/src/components/menus/TaskContainer/TaskContainer.tsx
+++ b/packages/app/src/components/menus/TaskContainer/TaskContainer.tsx
@@ -18,6 +18,7 @@ interface ContainerSettings {
   tasks?: UseQueryResult<Task[]> | Task[];
   activeFilter?: string;
   setIsInspecting?: (value: boolean) => void;
+  disableGrouping?: boolean;
 }
 
 export default function TaskContainer({
@@ -26,6 +27,7 @@ export default function TaskContainer({
   title,
   tasks,
   setIsInspecting,
+  disableGrouping = false,
 }: ContainerSettings) {
   const [appData] = useApp();
   const [taskFilter, setTaskFilter] = useState("incomplete");
@@ -45,7 +47,7 @@ export default function TaskContainer({
   if (skeleton) {
     return (
       <div className="group flex flex-col items-center w-full h-full my-2">
-        <div className="w-full flex flex-row items-center rounded-2xl bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 px-3 py-3 text-primary shadow-sm">
+        <div className="w-full flex flex-row items-center rounded-2xl bg-white dark:bg-(--surface-card) border border-slate-200 dark:border-(--surface-border) px-3 py-3 text-primary shadow-sm">
           <div className="w-full flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex flex-row items-center py-1">
               <ChevronRightIcon
@@ -59,9 +61,9 @@ export default function TaskContainer({
             </div>
             <div className="flex flex-row items-center sm:justify-end">
               <div className="flex w-full justify-start sm:justify-end">
-                <div className="flex rounded-full bg-white/70 border border-accent-blue/20 overflow-hidden">
+                <div className="flex rounded-full bg-white/70 dark:bg-(--surface-raised) border border-accent-blue/20 overflow-hidden">
                   <span className="px-2 py-1 text-xs text-accent-blue-700">All</span>
-                  <span className="px-2 py-1 text-xs text-slate-500">Incomplete</span>
+                  <span className="px-2 py-1 text-xs text-slate-500 dark:text-muted">Incomplete</span>
                 </div>
               </div>
             </div>
@@ -334,7 +336,7 @@ export default function TaskContainer({
           paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 2rem)",
         }}
       >
-        <div className="w-full max-w-xl rounded-2xl bg-white px-4 py-4 shadow-2xl ring-1 ring-accent-blue/10 dark:bg-slate-900/95">
+        <div className="w-full max-w-xl rounded-2xl bg-white px-4 py-4 shadow-2xl ring-1 ring-accent-blue/10 dark:bg-(--surface-card) dark:ring-(--surface-border)">
           <div className="flex items-center justify-between">
             <span className="text-sm font-semibold text-primary">
               {bulkAction === "group" ? "Update group" : "Edit tags"}
@@ -364,7 +366,7 @@ export default function TaskContainer({
                   value={bulkGroup}
                   onChange={(e) => setBulkGroup(e.target.value)}
                   placeholder="Set a group or leave blank to clear"
-                  className="w-full rounded-lg border border-accent-blue/20 bg-white px-3 py-2 text-sm text-primary shadow-inner focus:outline-hidden focus:ring-2 focus:ring-accent-blue/40 dark:bg-[rgba(15,23,42,0.7)]"
+                  className="w-full rounded-lg border border-accent-blue/20 bg-white px-3 py-2 text-sm text-primary shadow-inner focus:outline-hidden focus:ring-2 focus:ring-accent-blue/40 dark:bg-(--surface-raised)"
                 />
                 <div className="flex items-center gap-2">
                   <button
@@ -380,7 +382,7 @@ export default function TaskContainer({
                   </button>
                   <button
                     type="button"
-                    className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs font-semibold text-slate-700 shadow-xs transition hover:shadow-md hover:ring-2 hover:ring-slate-200 disabled:cursor-not-allowed disabled:opacity-60"
+                    className="rounded-lg border border-slate-200 bg-white dark:bg-(--surface-raised) dark:border-(--surface-border) dark:text-primary px-3 py-2 text-xs font-semibold text-slate-700 shadow-xs transition hover:shadow-md hover:ring-2 hover:ring-slate-200 disabled:cursor-not-allowed disabled:opacity-60"
                     disabled={!hasSelection || isBulkUpdating}
                     onClick={(e) => {
                       e.stopPropagation();
@@ -405,7 +407,7 @@ export default function TaskContainer({
                     <span className="text-muted">Selected: {selectedTaskIds.length}</span>
                   )}
                 </div>
-                <div className="flex flex-wrap items-center gap-2 rounded-xl border border-accent-blue/20 bg-white/90 p-2 shadow-inner focus-within:border-accent-blue dark:bg-[rgba(15,23,42,0.7)]">
+                <div className="flex flex-wrap items-center gap-2 rounded-xl border border-accent-blue/20 bg-white/90 p-2 shadow-inner focus-within:border-accent-blue dark:bg-(--surface-raised)">
                   {normalizedTags.length === 0 && (
                     <span className="text-sm text-muted px-1">No tags yet</span>
                   )}
@@ -437,7 +439,7 @@ export default function TaskContainer({
                       className={`rounded-full px-3 py-1 text-xs font-semibold transition ${
                         normalizedTags.includes(tag)
                           ? "bg-accent-blue text-white shadow-xs shadow-accent-blue/30"
-                          : "bg-white text-primary ring-1 ring-accent-blue/20 hover:ring-accent-blue/40"
+                          : "bg-white dark:bg-(--surface-raised) text-primary ring-1 ring-accent-blue/20 hover:ring-accent-blue/40"
                       }`}
                       onClick={() => {
                         setWorkingTags((prev) =>
@@ -465,7 +467,7 @@ export default function TaskContainer({
                   </button>
                   <button
                     type="button"
-                    className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs font-semibold text-slate-700 shadow-xs transition hover:shadow-md hover:ring-2 hover:ring-slate-200 disabled:cursor-not-allowed disabled:opacity-60"
+                    className="rounded-lg border border-slate-200 bg-white dark:bg-(--surface-raised) dark:border-(--surface-border) dark:text-primary px-3 py-2 text-xs font-semibold text-slate-700 shadow-xs transition hover:shadow-md hover:ring-2 hover:ring-slate-200 disabled:cursor-not-allowed disabled:opacity-60"
                     disabled={!hasSelection || isBulkUpdating}
                     onClick={(e) => {
                       e.stopPropagation();
@@ -501,7 +503,7 @@ export default function TaskContainer({
               <Disclosure.Button
                 onClick={async () => await handleClick(open)}
                 as="div"
-                className="w-full flex flex-row items-center rounded-2xl bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 px-3 py-3 text-primary shadow-sm"
+                className="w-full flex flex-row items-center rounded-2xl bg-white dark:bg-(--surface-card) border border-slate-200 dark:border-(--surface-border) px-3 py-3 text-primary shadow-sm"
               >
                 <div className="w-full flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                   <div className="flex flex-row items-center py-1">
@@ -521,12 +523,12 @@ export default function TaskContainer({
                   </div>
                   <div className="flex flex-row items-center sm:justify-end">
                     <div className="flex w-full flex-wrap items-center justify-start sm:justify-end gap-2">
-                      <div className="flex rounded-full bg-white/70 border border-accent-blue/20 overflow-hidden">
+                      <div className="flex rounded-full bg-white/70 dark:bg-(--surface-raised) border border-accent-blue/20 overflow-hidden">
                         <button
                           type="button"
                           className={`px-3 py-1 text-xs font-semibold transition ${taskFilter === "all"
                             ? "bg-accent-blue text-white"
-                            : "text-slate-600"
+                            : "text-slate-600 dark:text-muted"
                             }`}
                           onClick={(e) => {
                             e.stopPropagation();
@@ -539,7 +541,7 @@ export default function TaskContainer({
                           type="button"
                           className={`px-3 py-1 text-xs font-semibold transition ${taskFilter === "incomplete"
                             ? "bg-accent-blue text-white"
-                            : "text-slate-600"
+                            : "text-slate-600 dark:text-muted"
                             }`}
                           onClick={(e) => {
                             e.stopPropagation();
@@ -552,7 +554,7 @@ export default function TaskContainer({
                       {!selectionMode && (
                         <button
                           type="button"
-                          className="rounded-lg border border-accent-blue/30 bg-white px-3 py-1.5 text-xs font-semibold text-accent-blue shadow-xs transition hover:shadow-md hover:ring-1 hover:ring-accent-blue/30"
+                          className="rounded-lg border border-accent-blue/30 bg-white dark:bg-(--surface-raised) dark:border-(--surface-border) px-3 py-1.5 text-xs font-semibold text-accent-blue shadow-xs transition hover:shadow-md hover:ring-1 hover:ring-accent-blue/30"
                           onClick={(e) => {
                             e.stopPropagation();
                             setSelectionMode(true);
@@ -578,12 +580,12 @@ export default function TaskContainer({
                             <Menu.Button
                               disabled={!hasSelection || isBulkUpdating}
                               onClick={(e) => e.stopPropagation()}
-                              className="flex items-center gap-1 rounded-lg border border-slate-200 bg-white px-2.5 py-1.5 text-xs font-semibold text-slate-700 shadow-xs transition hover:shadow-md hover:ring-1 hover:ring-slate-200 disabled:opacity-60 disabled:cursor-not-allowed"
+                              className="flex items-center gap-1 rounded-lg border border-slate-200 bg-white dark:bg-(--surface-raised) dark:border-(--surface-border) dark:text-primary px-2.5 py-1.5 text-xs font-semibold text-slate-700 shadow-xs transition hover:shadow-md hover:ring-1 hover:ring-slate-200 disabled:opacity-60 disabled:cursor-not-allowed"
                             >
                               <EllipsisHorizontalIcon className="h-4 w-4" />
                               <span>Actions</span>
                             </Menu.Button>
-                            <Menu.Items className="absolute left-0 right-auto z-130 mt-2 w-52 max-w-[90vw] origin-top-left rounded-xl bg-white py-1 shadow-lg ring-1 ring-black/5 focus:outline-hidden dark:bg-slate-900/90 md:left-auto md:right-0 md:origin-top-right">
+                            <Menu.Items className="absolute left-0 right-auto z-130 mt-2 w-52 max-w-[90vw] origin-top-left rounded-xl bg-white py-1 shadow-lg ring-1 ring-black/5 focus:outline-hidden dark:bg-(--surface-raised) dark:ring-(--surface-border) md:left-auto md:right-0 md:origin-top-right">
                               {[
                                 { key: "group", label: "Edit group" },
                                 { key: "tags", label: "Edit tags" },
@@ -594,8 +596,8 @@ export default function TaskContainer({
                                       type="button"
                                       className={`flex w-full items-center justify-between px-3 py-2 text-left text-sm ${
                                         active
-                                          ? "bg-accent-blue/10 text-slate-900 dark:text-white"
-                                          : "text-slate-800 dark:text-slate-100"
+                                          ? "bg-accent-blue/10 text-slate-900 dark:bg-(--accent-subtle) dark:text-primary"
+                                          : "text-slate-800 dark:text-primary"
                                       }`}
                                       onClick={(e) => {
                                         e.stopPropagation();
@@ -604,10 +606,10 @@ export default function TaskContainer({
                                     >
                                       <span>{item.label}</span>
                                       {item.key === "group" && sharedGroup && (
-                                        <span className="text-[11px] text-slate-500 dark:text-slate-300">#{sharedGroup}</span>
+                                        <span className="text-[11px] text-slate-500 dark:text-muted">#{sharedGroup}</span>
                                       )}
                                       {item.key === "tags" && uniqueTags.length > 0 && (
-                                        <span className="text-[11px] text-slate-500 dark:text-slate-300">{uniqueTags.length} tags</span>
+                                        <span className="text-[11px] text-slate-500 dark:text-muted">{uniqueTags.length} tags</span>
                                       )}
                                     </button>
                                   )}
@@ -617,7 +619,7 @@ export default function TaskContainer({
                           </Menu>
                           <button
                             type="button"
-                            className="rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 shadow-xs transition hover:shadow-md hover:ring-1 hover:ring-slate-200 disabled:opacity-60 disabled:cursor-not-allowed"
+                            className="rounded-lg border border-slate-200 bg-white dark:bg-(--surface-raised) dark:border-(--surface-border) dark:text-primary px-3 py-1.5 text-xs font-semibold text-slate-700 shadow-xs transition hover:shadow-md hover:ring-1 hover:ring-slate-200 disabled:opacity-60 disabled:cursor-not-allowed"
                             disabled={isBulkUpdating}
                             onClick={(e) => {
                               e.stopPropagation();
@@ -645,6 +647,7 @@ export default function TaskContainer({
                   animatingIds={animatingIds}
                   activeDate={appData.activeDate}
                   onTaskComplete={(task: Task) => showCompletionToast(`Task completed: ${task.title || "Untitled"}`)}
+                  disableGrouping={disableGrouping}
                 />
                 {/* )} */}
               </Disclosure.Panel>

--- a/packages/app/src/components/task/TaskItem.tsx
+++ b/packages/app/src/components/task/TaskItem.tsx
@@ -56,7 +56,6 @@ export function TaskItem({ skeleton, item, setIsInspecting, taskFilter, selectio
 
   if (!item) item = { title: "", date: new Date(), done: false, tags: [] };
 
-  const tags = Array.isArray(item.tags) ? item.tags.map((tag) => (typeof tag === "string" ? tag : null)).filter(Boolean) as string[] : [];
 
   const handleToggleSelect = () => {
     if (!onToggleSelect || !item?.id) return;
@@ -153,31 +152,19 @@ export function TaskItem({ skeleton, item, setIsInspecting, taskFilter, selectio
             }}
           />
           <div className="w-full">
-            <div className="w-full flex flex-row items-center justify-between gap-2">
+            <div className="w-full flex flex-row items-center gap-2">
               <div className="flex flex-row items-center min-w-0 flex-1">
                 <TaskItemTitle text={item.title} />
-                {!!item.priority && item.priority > 0 && (
-                  <span className="ml-1 flex-shrink-0 text-xs font-bold text-red-500">
-                    {"!".repeat(item.priority)}
-                  </span>
-                )}
               </div>
               <div className="flex-shrink-0 w-20">
                 <TaskItemDate task={item} />
               </div>
+              {!!item.priority && item.priority > 0 && (
+                <span className="flex-shrink-0 ml-1 text-xs font-bold text-red-500">
+                  {"!".repeat(item.priority)}
+                </span>
+              )}
             </div>
-            {tags.length > 0 && isPending && (
-              <div className="mt-1 flex flex-wrap gap-2 px-2">
-                {tags.map((tag) => (
-                  <span
-                    key={tag}
-                    className="rounded-full bg-accent-blue/10 px-2 py-1 text-[11px] font-semibold uppercase tracking-wide text-accent-blue-800 ring-1 ring-accent-blue/20"
-                  >
-                    #{tag}
-                  </span>
-                ))}
-              </div>
-            )}
           </div>
         </div>
       </TaskItemShell>

--- a/packages/app/src/components/task/TaskItemDate.tsx
+++ b/packages/app/src/components/task/TaskItemDate.tsx
@@ -55,7 +55,7 @@ export default function TaskItemDate({ task }: { task: Task }) {
               isOverdue(date, new Date()) ? "text-red-400" : "text-muted"
             }`}
           >
-            <h1 className="text-small text-right">{checkRelative(date)}</h1>
+            <h1 className="text-small text-right whitespace-nowrap">{checkRelative(date)}</h1>
           </div>
           {/* <img
             src={today_icon}

--- a/packages/app/src/components/task/TaskItemShell.tsx
+++ b/packages/app/src/components/task/TaskItemShell.tsx
@@ -12,7 +12,7 @@ interface TaskItemShellProps {
 export default function TaskItemShell({ skeleton, children, task, activeDate, className = "", ...props }: React.PropsWithChildren<TaskItemShellProps>) {
   if (skeleton) {
     return (
-      <div className="group flex flex-col w-full rounded-2xl bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 px-4 py-3 shadow-sm backdrop-blur-xs transition duration-200 ease-out hover:shadow-md hover:border-accent-blue/30 text-primary">
+      <div className="group flex flex-col w-full rounded-2xl bg-slate-50 dark:bg-(--surface-raised) border border-slate-200 dark:border-(--surface-border) px-4 py-3 shadow-sm backdrop-blur-xs transition duration-200 ease-out hover:shadow-md hover:border-accent-blue/30 text-primary">
         {children}
       </div>
     )
@@ -24,7 +24,7 @@ export default function TaskItemShell({ skeleton, children, task, activeDate, cl
     <div
       {...props}
       data-completed={isCompleted}
-      className={`group flex flex-col w-full rounded-2xl bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 px-3.5 py-3 shadow-sm backdrop-blur-xs transition-all duration-300 ease-out hover:shadow-md hover:border-accent-blue/30 text-primary ${isCompleted ? "opacity-30 translate-y-1 scale-[0.99]" : "opacity-100"} ${className}`}
+      className={`group flex flex-col w-full rounded-2xl bg-slate-50 dark:bg-(--surface-raised) border border-slate-200 dark:border-(--surface-border) px-3.5 py-3 shadow-sm backdrop-blur-xs transition-all duration-300 ease-out hover:shadow-md hover:border-accent-blue/30 text-primary ${isCompleted ? "opacity-30 translate-y-1 scale-[0.99]" : "opacity-100"} ${className}`}
     >
       {children}
     </div>

--- a/packages/app/src/components/task/TaskItemTitle.tsx
+++ b/packages/app/src/components/task/TaskItemTitle.tsx
@@ -1,7 +1,7 @@
 export default function TaskItemTitle({ text }: { text: string }) {
   return (
     <div
-      className="w-full text-lg mx-3 ml-2 mr-6 whitespace-normal wrap-break-word text-primary"
+      className="w-full text-lg mx-3 ml-2 mr-6 truncate text-primary"
       title={text || "No Title"}
     >
       {text || "No Title"}

--- a/packages/app/src/components/tasks/TaskMenu.tsx
+++ b/packages/app/src/components/tasks/TaskMenu.tsx
@@ -15,6 +15,7 @@ interface TaskMenuProps {
   animatingIds?: string[];
   activeDate?: Date;
   onTaskComplete?: any;
+  disableGrouping?: boolean;
 }
 
 export default function TaskMenu({
@@ -27,7 +28,8 @@ export default function TaskMenu({
   toggleSelection,
   animatingIds = [],
   activeDate,
-  onTaskComplete
+  onTaskComplete,
+  disableGrouping = false,
 }: TaskMenuProps) {
   const [collapsedGroups, setCollapsedGroups] = useState<string[]>([]);
   const [orderedTasks, setOrderedTasks] = useState<any[]>([]);
@@ -63,6 +65,10 @@ export default function TaskMenu({
   }, [tasks, taskFilter, activeDate]);
 
   const { grouped, ungrouped } = useMemo(() => {
+    if (disableGrouping) {
+      return { grouped: {} as Record<string, any[]>, ungrouped: orderedTasks };
+    }
+
     const groupedTasks: Record<string, any[]> = {};
     const ungroupedTasks: any[] = [];
 
@@ -124,33 +130,49 @@ export default function TaskMenu({
     </div>
   );
 
-  return (
-    <div className="w-full h-full flex flex-col items-center ">
-      <div className="w-full h-full pb-4 flex flex-col gap-3 justify-start py-4">
-        {ungrouped.length > 0 && ungrouped.map(renderTask)}
+  const numGroups = groupedEntries.length;
+  const groupGridClass =
+    numGroups <= 1
+      ? "grid-cols-1"
+      : numGroups <= 4
+        ? "grid-cols-1 md:grid-cols-2"
+        : "grid-cols-1 md:grid-cols-3";
 
-        {groupedEntries.map(([groupName, list]) => {
-          const isCollapsed = collapsedGroups.includes(groupName);
-          return (
-            <div
-              key={groupName}
-              className="w-full"
-            >
-              <button
-                type="button"
-                onClick={() => toggleGroup(groupName)}
-                className="w-full text-left"
-              >
-                {renderGroupHeader(groupName, isCollapsed, list.length)}
-              </button>
-              {!isCollapsed && (
-                <div className="mt-2 flex flex-col gap-2">
-                  {list.map((task: any) => renderTask(task))}
+  return (
+    <div className="w-full h-full flex flex-col">
+      <div className="w-full h-full pb-4 flex flex-col gap-3 py-4">
+        {ungrouped.length > 0 && (
+          <div className="flex flex-col gap-2">
+            {ungrouped.map(renderTask)}
+          </div>
+        )}
+
+        {groupedEntries.length > 0 && (
+          <div className={`grid gap-3 ${groupGridClass}`}>
+            {groupedEntries.map(([groupName, list]) => {
+              const isCollapsed = collapsedGroups.includes(groupName);
+              return (
+                <div
+                  key={groupName}
+                  className="rounded-2xl surface-card border shadow-xs overflow-hidden flex flex-col"
+                >
+                  <button
+                    type="button"
+                    onClick={() => toggleGroup(groupName)}
+                    className="w-full px-3 pt-3 pb-2 text-left hover:bg-silver-100/60 dark:hover:bg-(--surface-raised) transition-colors"
+                  >
+                    {renderGroupHeader(groupName, isCollapsed, list.length)}
+                  </button>
+                  {!isCollapsed && (
+                    <div className="px-3 pb-3 flex flex-col gap-2">
+                      {list.map((task: any) => renderTask(task))}
+                    </div>
+                  )}
                 </div>
-              )}
-            </div>
-          );
-        })}
+              );
+            })}
+          </div>
+        )}
 
         {visibleTasks.length === 0 && (
           <h1 className="text-lg text-accent-blue text-center">No Tasks</h1>

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -285,6 +285,3 @@ select option {
   padding-bottom: calc(env(safe-area-inset-bottom) / 2);
 }
 
-.hidden {
-  display: none;
-}

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -128,12 +128,18 @@
 }
 
 .dark {
-  --app-background: #121720;           /* vulcan-950 */
-  --app-text: #e7ebf3;
-  --muted-text: #a6b9d3;              /* vulcan-300 */
-  --surface-card: rgba(44, 58, 78, 0.96);   /* vulcan-900 */
-  --surface-border: rgba(54, 76, 110, 0.45); /* vulcan-700 */
-  --nav-border: rgba(54, 76, 110, 0.35);
+  --app-background:      #111319;
+  --surface-card:        #1a1d26;
+  --surface-raised:      #222630;
+  --surface-border:      #2d3244;
+  --nav-border:          #22263a;
+  --app-text:            #e2e5ee;
+  --secondary-text:      #9198ae;
+  --muted-text:          #52586e;
+  --accent:              #378bd9;
+  --accent-hover:        #307acf;
+  --accent-subtle:       rgba(55, 139, 217, 0.14);
+  --accent-subtle-hover: rgba(55, 139, 217, 0.22);
   color-scheme: dark;
 }
 
@@ -183,6 +189,10 @@ body {
 
 .text-primary {
   color: var(--app-text);
+}
+
+.text-secondary {
+  color: var(--secondary-text);
 }
 
 .text-muted {
@@ -252,13 +262,13 @@ select option {
 .dark input,
 .dark textarea,
 .dark select {
-  background-color: #253350;
+  background-color: var(--surface-raised);
   color: var(--app-text);
   border-color: var(--surface-border);
 }
 
 .dark select option {
-  background-color: #253350;
+  background-color: var(--surface-raised);
   color: var(--app-text);
 }
 

--- a/packages/app/src/pages/(Home)/DueCapsule.tsx
+++ b/packages/app/src/pages/(Home)/DueCapsule.tsx
@@ -2,6 +2,7 @@ interface DueCapsule {
     skeleton?: boolean;
     count?: number;
     category?: string;
+    label?: string;
     onClick?: (e: React.MouseEvent) => void;
 }
 
@@ -21,31 +22,47 @@ const variants: Record<string, { bg: string; countColor: string; labelColor: str
         countColor: "text-violet-700 dark:text-violet-300",
         labelColor: "text-violet-600/80 dark:text-violet-300/80",
     },
+    "overdue-active": {
+        bg: "bg-red-50 dark:bg-[rgba(248,113,113,0.13)]",
+        countColor: "text-red-700 dark:text-red-300",
+        labelColor: "text-red-600/80 dark:text-red-300/80",
+    },
+    "overdue-clear": {
+        bg: "bg-emerald-50 dark:bg-[rgba(52,211,153,0.12)]",
+        countColor: "text-emerald-700 dark:text-emerald-300",
+        labelColor: "text-emerald-600/80 dark:text-emerald-300/80",
+    },
 };
 
-export default function DueCapsule({ skeleton, count, category, onClick }: DueCapsule) {
+const displayLabel = (category: string, label?: string) => {
+    if (label) return label;
+    if (category === "this week") return "This Week";
+    return category.charAt(0).toUpperCase() + category.slice(1);
+};
+
+export default function DueCapsule({ skeleton, count, category, label, onClick }: DueCapsule) {
     const v = variants[category ?? "today"] ?? variants.today;
 
     if (skeleton)
         return (
-            <div className={`relative flex h-full flex-col gap-0.5 overflow-hidden rounded-2xl ${v.bg} px-4 py-3`}>
-                <span className={`text-2xl font-bold ${v.countColor}`}>0</span>
-                <span className={`text-xs font-semibold leading-tight ${v.labelColor}`}>
-                    Tasks due {category}
+            <div className={`flex h-full items-center justify-between gap-4 overflow-hidden rounded-2xl ${v.bg} px-4 py-3`}>
+                <span className={`text-sm font-semibold leading-tight capitalize ${v.labelColor}`}>
+                    {displayLabel(category ?? "today", label)}
                 </span>
+                <span className={`text-2xl font-bold tabular-nums ${v.countColor}`}>0</span>
             </div>
-        )
+        );
 
     return (
         <button
             type="button"
             onClick={onClick}
-            className={`relative flex h-full w-full flex-col gap-0.5 overflow-hidden rounded-2xl ${v.bg} px-4 py-3 text-left transition hover:brightness-95 dark:hover:brightness-110`}
+            className={`flex h-full w-full items-center justify-between gap-4 overflow-hidden rounded-2xl ${v.bg} px-4 py-3 text-left transition hover:brightness-95 dark:hover:brightness-110`}
         >
-            <span className={`text-2xl font-bold ${v.countColor}`}>{count}</span>
-            <span className={`text-xs font-semibold leading-tight ${v.labelColor}`}>
-                {count !== 1 ? "Tasks" : "Task"} due {category}
+            <span className={`text-sm font-semibold leading-tight ${v.labelColor}`}>
+                {displayLabel(category ?? "today", label)}
             </span>
+            <span className={`text-2xl font-bold tabular-nums ${v.countColor}`}>{count ?? 0}</span>
         </button>
-    )
+    );
 }

--- a/packages/app/src/pages/(Home)/HomeAgenda.tsx
+++ b/packages/app/src/pages/(Home)/HomeAgenda.tsx
@@ -54,18 +54,15 @@ export default function HomeAgenda({ skeleton }: AgendaProps) {
             <div className="flex flex-col gap-3">
                 <div className="flex items-center justify-between px-1">
                     <span className="text-xs font-semibold uppercase tracking-widest text-muted">Your Agenda</span>
-                    <span className="rounded-full bg-accent-blue-50 px-2.5 py-0.5 text-xs font-semibold text-accent-blue-700 dark:bg-[rgba(99,102,241,0.12)] dark:text-primary">
+                    <span className="rounded-full bg-accent-blue-50 px-2.5 py-0.5 text-xs font-semibold text-accent-blue-700 dark:bg-(--accent-subtle) dark:text-primary">
                         Updating...
                     </span>
                 </div>
-                <div className="grid grid-cols-3 gap-2">
+                <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
                     <DueCapsule skeleton category="today" />
                     <DueCapsule skeleton category="tomorrow" />
                     <DueCapsule skeleton category="this week" />
-                </div>
-                <div className="flex items-center justify-between rounded-2xl border border-dashed border-red-200 bg-red-50/60 px-4 py-3 text-red-600 dark:border-red-400/40 dark:bg-[rgba(248,113,113,0.12)] dark:text-red-200">
-                    <span className="text-base font-semibold">Overdue Tasks</span>
-                    <span className="text-3xl font-semibold">0</span>
+                    <DueCapsule skeleton category="overdue-clear" label="Overdue" />
                 </div>
             </div>
         )
@@ -74,53 +71,32 @@ export default function HomeAgenda({ skeleton }: AgendaProps) {
         <div className="flex flex-col gap-3">
             <div className="flex items-center justify-between px-1">
                 <span className="text-xs font-semibold uppercase tracking-widest text-muted">Your Agenda</span>
-                <span className="rounded-full bg-accent-blue-50 px-2.5 py-0.5 text-xs font-semibold text-accent-blue-700 dark:bg-[rgba(99,102,241,0.12)] dark:text-primary">
+                <span className="rounded-full bg-accent-blue-50 px-2.5 py-0.5 text-xs font-semibold text-accent-blue-700 dark:bg-(--accent-subtle) dark:text-primary">
                     Live sync
                 </span>
             </div>
-            <div className="grid grid-cols-3 gap-2">
-                {tasks.isSuccess && (
-                    <DueCapsule
-                        count={counts.today}
-                        category="today"
-                        onClick={() => navigate("/calendar?scope=today&view=week")}
-                    />
-                )}
-                {tasks.isSuccess && (
-                    <DueCapsule
-                        count={counts.tomorrow}
-                        category="tomorrow"
-                        onClick={() => navigate("/calendar?scope=tomorrow&view=week")}
-                    />
-                )}
-                {tasks.isSuccess && (
-                    <DueCapsule
-                        count={counts.week}
-                        category="this week"
-                        onClick={() => navigate("/calendar?scope=week&view=week")}
-                    />
-                )}
-            </div>
-            <div
-                role="button"
-                tabIndex={0}
-                onClick={() => navigate("/calendar?scope=overdue&view=week")}
-                onKeyDown={(e) => {
-                    if (e.key === "Enter" || e.key === " ") {
-                        e.preventDefault();
-                        navigate("/calendar?scope=overdue&view=week");
-                    }
-                }}
-                className={`group flex items-center justify-between rounded-2xl border px-4 py-3 cursor-pointer transition hover:brightness-[0.97] dark:hover:brightness-110 ${
-                    tasks.isSuccess && counts.overdue > 0
-                        ? "border-red-200 bg-red-50/80 text-red-700 dark:border-red-400/40 dark:bg-[rgba(248,113,113,0.12)] dark:text-red-200"
-                        : "border-emerald-200/70 bg-emerald-50/80 text-emerald-700 dark:border-emerald-300/40 dark:bg-[rgba(52,211,153,0.12)] dark:text-emerald-200"
-                }`}
-            >
-                <span className="text-base font-semibold">Overdue Tasks</span>
-                <span className="text-3xl font-bold">
-                    {tasks.isSuccess ? counts.overdue : "—"}
-                </span>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+                <DueCapsule
+                    count={tasks.isSuccess ? counts.today : 0}
+                    category="today"
+                    onClick={() => navigate("/calendar?scope=today&view=week")}
+                />
+                <DueCapsule
+                    count={tasks.isSuccess ? counts.tomorrow : 0}
+                    category="tomorrow"
+                    onClick={() => navigate("/calendar?scope=tomorrow&view=week")}
+                />
+                <DueCapsule
+                    count={tasks.isSuccess ? counts.week : 0}
+                    category="this week"
+                    onClick={() => navigate("/calendar?scope=week&view=week")}
+                />
+                <DueCapsule
+                    count={tasks.isSuccess ? counts.overdue : 0}
+                    category={tasks.isSuccess && counts.overdue > 0 ? "overdue-active" : "overdue-clear"}
+                    label="Overdue"
+                    onClick={() => navigate("/calendar?scope=overdue&view=week")}
+                />
             </div>
         </div>
     )

--- a/packages/app/src/pages/(Home)/HomeAgenda.tsx
+++ b/packages/app/src/pages/(Home)/HomeAgenda.tsx
@@ -69,11 +69,8 @@ export default function HomeAgenda({ skeleton }: AgendaProps) {
 
     return (
         <div className="flex flex-col gap-3">
-            <div className="flex items-center justify-between px-1">
+            <div className="px-1">
                 <span className="text-xs font-semibold uppercase tracking-widest text-muted">Your Agenda</span>
-                <span className="rounded-full bg-accent-blue-50 px-2.5 py-0.5 text-xs font-semibold text-accent-blue-700 dark:bg-(--accent-subtle) dark:text-primary">
-                    Live sync
-                </span>
             </div>
             <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
                 <DueCapsule

--- a/packages/app/src/pages/(Home)/HomeAnnouncements.tsx
+++ b/packages/app/src/pages/(Home)/HomeAnnouncements.tsx
@@ -2,7 +2,20 @@ import { useState } from "react";
 import { useAuth } from "@/hooks/auth";
 import { useUnreadAnnouncements, useMarkAnnouncementsRead } from "@/hooks/announcements";
 import { useAnnouncementRenderer } from "@/utils/announcementRenderer";
-import { ChevronDownIcon, ChevronRightIcon } from "@heroicons/react/20/solid";
+import { ChevronDownIcon, ChevronRightIcon, XMarkIcon } from "@heroicons/react/20/solid";
+
+type LocalNote = { id: string; text: string };
+
+const NOTES_KEY = "home_notes_v1";
+
+function loadNotes(): LocalNote[] {
+  try { return JSON.parse(localStorage.getItem(NOTES_KEY) ?? "[]"); }
+  catch { return []; }
+}
+
+function persistNotes(notes: LocalNote[]) {
+  localStorage.setItem(NOTES_KEY, JSON.stringify(notes));
+}
 
 export default function HomeAnnouncements() {
     const auth = useAuth();
@@ -11,10 +24,27 @@ export default function HomeAnnouncements() {
     const markRead = useMarkAnnouncementsRead();
     const { renderBody } = useAnnouncementRenderer();
     const [expanded, setExpanded] = useState<string | null>(null);
+    const [notes, setNotes] = useState<LocalNote[]>(loadNotes);
+    const [draft, setDraft] = useState("");
 
     const handleDismiss = (id: string) => {
         markRead.mutate([id]);
         if (expanded === id) setExpanded(null);
+    };
+
+    const addNote = () => {
+        const text = draft.trim();
+        if (!text) return;
+        const updated = [{ id: crypto.randomUUID(), text }, ...notes];
+        setNotes(updated);
+        persistNotes(updated);
+        setDraft("");
+    };
+
+    const removeNote = (id: string) => {
+        const updated = notes.filter((n) => n.id !== id);
+        setNotes(updated);
+        persistNotes(updated);
     };
 
     const list = announcements.data ?? [];
@@ -22,7 +52,7 @@ export default function HomeAnnouncements() {
     return (
         <div className="flex flex-col gap-3">
             <div className="flex items-center justify-between px-1">
-                <span className="text-xs font-semibold uppercase tracking-widest text-muted">Announcements</span>
+                <span className="text-xs font-semibold uppercase tracking-widest text-muted">Notes</span>
                 {list.length > 0 && (
                     <span className="rounded-full bg-accent-blue/10 px-2.5 py-0.5 text-xs font-semibold text-accent-blue-700 dark:bg-[rgba(48,122,207,0.15)] dark:text-accent-blue-300">
                         {list.length} new
@@ -30,15 +60,29 @@ export default function HomeAnnouncements() {
                 )}
             </div>
 
+            {/* Personal notes */}
+            {notes.length > 0 && (
+                <ul className="flex flex-col gap-2">
+                    {notes.map((note) => (
+                        <li key={note.id} className="group rounded-2xl surface-card border px-4 py-3 flex items-start gap-2 shadow-xs">
+                            <p className="flex-1 text-sm text-primary leading-snug whitespace-pre-wrap">{note.text}</p>
+                            <button
+                                type="button"
+                                onClick={() => removeNote(note.id)}
+                                className="shrink-0 mt-0.5 opacity-0 group-hover:opacity-100 focus:opacity-100 text-muted hover:text-red-500 transition"
+                                aria-label="Remove note"
+                            >
+                                <XMarkIcon className="h-4 w-4" />
+                            </button>
+                        </li>
+                    ))}
+                </ul>
+            )}
+
+            {/* Server announcements */}
             {announcements.isLoading && (
                 <div className="rounded-2xl surface-card border px-4 py-3 text-sm text-muted animate-pulse">
                     Loading...
-                </div>
-            )}
-
-            {!announcements.isLoading && list.length === 0 && (
-                <div className="rounded-2xl surface-card border px-4 py-4 text-center text-sm text-muted">
-                    You're all caught up!
                 </div>
             )}
 
@@ -100,6 +144,28 @@ export default function HomeAnnouncements() {
                     })}
                 </ul>
             )}
+
+            {/* Add a note — desktop only */}
+            <div className="hidden md:flex flex-col gap-2">
+                <textarea
+                    value={draft}
+                    onChange={(e) => setDraft(e.target.value)}
+                    placeholder="Add a note..."
+                    rows={2}
+                    onKeyDown={(e) => {
+                        if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) addNote();
+                    }}
+                    className="w-full rounded-2xl border border-(--surface-border) !bg-(--surface-card) px-4 py-3 text-sm text-primary resize-none placeholder:text-muted focus:outline-none focus:border-accent-blue/50 focus:ring-1 focus:ring-accent-blue/20 transition"
+                />
+                <button
+                    type="button"
+                    onClick={addNote}
+                    disabled={!draft.trim()}
+                    className="self-end rounded-lg bg-accent-blue px-3 py-1.5 text-xs font-semibold text-white shadow-xs shadow-accent-blue/30 hover:-translate-y-px transition disabled:opacity-50 disabled:pointer-events-none"
+                >
+                    Save note
+                </button>
+            </div>
         </div>
     );
 }

--- a/packages/app/src/pages/(Home)/HomeAnnouncements.tsx
+++ b/packages/app/src/pages/(Home)/HomeAnnouncements.tsx
@@ -1,0 +1,105 @@
+import { useState } from "react";
+import { useAuth } from "@/hooks/auth";
+import { useUnreadAnnouncements, useMarkAnnouncementsRead } from "@/hooks/announcements";
+import { useAnnouncementRenderer } from "@/utils/announcementRenderer";
+import { ChevronDownIcon, ChevronRightIcon } from "@heroicons/react/20/solid";
+
+export default function HomeAnnouncements() {
+    const auth = useAuth();
+    const isLoggedIn = auth.isSuccess && (auth.data?.message === "Logged In" || !auth.data?.statusCode);
+    const announcements = useUnreadAnnouncements(Boolean(isLoggedIn));
+    const markRead = useMarkAnnouncementsRead();
+    const { renderBody } = useAnnouncementRenderer();
+    const [expanded, setExpanded] = useState<string | null>(null);
+
+    const handleDismiss = (id: string) => {
+        markRead.mutate([id]);
+        if (expanded === id) setExpanded(null);
+    };
+
+    const list = announcements.data ?? [];
+
+    return (
+        <div className="flex flex-col gap-3">
+            <div className="flex items-center justify-between px-1">
+                <span className="text-xs font-semibold uppercase tracking-widest text-muted">Announcements</span>
+                {list.length > 0 && (
+                    <span className="rounded-full bg-accent-blue/10 px-2.5 py-0.5 text-xs font-semibold text-accent-blue-700 dark:bg-[rgba(48,122,207,0.15)] dark:text-accent-blue-300">
+                        {list.length} new
+                    </span>
+                )}
+            </div>
+
+            {announcements.isLoading && (
+                <div className="rounded-2xl surface-card border px-4 py-3 text-sm text-muted animate-pulse">
+                    Loading...
+                </div>
+            )}
+
+            {!announcements.isLoading && list.length === 0 && (
+                <div className="rounded-2xl surface-card border px-4 py-4 text-center text-sm text-muted">
+                    You're all caught up!
+                </div>
+            )}
+
+            {list.length > 0 && (
+                <ul className="flex flex-col gap-2">
+                    {list.map((item) => {
+                        const isOpen = expanded === item.id;
+                        const formattedDate = new Date(item.date).toLocaleDateString(undefined, {
+                            month: "short",
+                            day: "numeric",
+                        });
+
+                        return (
+                            <li key={item.id} className="rounded-2xl surface-card border shadow-xs overflow-hidden">
+                                <button
+                                    type="button"
+                                    onClick={() => setExpanded(isOpen ? null : item.id)}
+                                    className="flex w-full items-start justify-between gap-2 px-4 py-3 text-left transition hover:bg-silver-100/60 dark:hover:bg-vulcan-800/40"
+                                >
+                                    <div className="flex min-w-0 flex-1 items-start gap-2">
+                                        {isOpen
+                                            ? <ChevronDownIcon className="mt-0.5 h-4 w-4 shrink-0 text-muted" />
+                                            : <ChevronRightIcon className="mt-0.5 h-4 w-4 shrink-0 text-muted" />
+                                        }
+                                        <span className="text-sm font-semibold text-primary leading-snug">{item.title}</span>
+                                    </div>
+                                    <span className="shrink-0 text-xs text-muted pt-0.5">{formattedDate}</span>
+                                </button>
+
+                                {isOpen && (
+                                    <div className="border-t border-(--surface-border) px-4 pb-4 pt-3 flex flex-col gap-3">
+                                        <div className="flex flex-col gap-1.5">
+                                            {renderBody(item.body)}
+                                        </div>
+                                        <div className="flex items-center gap-2 pt-1">
+                                            {item.ctaTitle && item.ctaAction && (
+                                                <a
+                                                    href={item.ctaAction.startsWith("http") ? item.ctaAction : undefined}
+                                                    target={item.ctaAction.startsWith("http") ? "_blank" : undefined}
+                                                    rel="noopener noreferrer"
+                                                    className="rounded-lg bg-accent-blue px-3 py-1.5 text-xs font-semibold text-white shadow-xs shadow-accent-blue/30 hover:-translate-y-px transition"
+                                                >
+                                                    {item.ctaTitle}
+                                                </a>
+                                            )}
+                                            <button
+                                                type="button"
+                                                onClick={() => handleDismiss(item.id)}
+                                                disabled={markRead.isPending}
+                                                className="rounded-lg border border-(--surface-border) px-3 py-1.5 text-xs font-semibold text-muted hover:text-primary transition hover:-translate-y-px disabled:opacity-60"
+                                            >
+                                                Dismiss
+                                            </button>
+                                        </div>
+                                    </div>
+                                )}
+                            </li>
+                        );
+                    })}
+                </ul>
+            )}
+        </div>
+    );
+}

--- a/packages/app/src/pages/(Home)/HomeIntroduction.tsx
+++ b/packages/app/src/pages/(Home)/HomeIntroduction.tsx
@@ -53,21 +53,16 @@ export default function HomeIntroduction({ skeleton, user, today }: Introduction
             </div>
 
             {/* Desktop: compact header */}
-            <div className="hidden md:flex items-center justify-between gap-4 pt-1 pb-2 border-b border-(--surface-border)">
-                <div className="flex flex-col">
-                    <h1 className="text-2xl font-semibold text-primary">
-                        Hello{hasName ? `, ${user.data.first}` : ""}!
-                    </h1>
-                    <a
-                        href={`/calendar?scope=today&view=week`}
-                        className="text-sm text-muted hover:text-primary transition-colors"
-                    >
-                        {getNameByDate(activeDay.getDay() as DaysAsNumbers)}, {getNameByMonth(activeDay.getMonth() as MonthsAsNumbers)} {getDateDD(activeDay)}
-                    </a>
-                </div>
-                <span className="shrink-0 rounded-full bg-accent-blue/10 px-3 py-1 text-xs font-semibold text-accent-blue-700 dark:bg-(--accent-subtle) dark:text-accent-blue-300">
-                    Live sync
-                </span>
+            <div className="hidden md:flex items-center justify-between pt-1 pb-2 border-b border-(--surface-border)">
+                <h1 className="text-2xl font-semibold text-primary">
+                    Hello{hasName ? `, ${user.data.first}` : ""}!
+                </h1>
+                <a
+                    href={`/calendar?scope=today&view=week`}
+                    className="text-sm text-muted hover:text-primary transition-colors"
+                >
+                    {getNameByDate(activeDay.getDay() as DaysAsNumbers)}, {getNameByMonth(activeDay.getMonth() as MonthsAsNumbers)} {getDateDD(activeDay)}
+                </a>
             </div>
         </>
     )

--- a/packages/app/src/pages/(Home)/HomeIntroduction.tsx
+++ b/packages/app/src/pages/(Home)/HomeIntroduction.tsx
@@ -12,10 +12,9 @@ export default function HomeIntroduction({ skeleton, user, today }: Introduction
             <>
                 <div className="relative overflow-hidden rounded-3xl bg-linear-to-r from-accent-blue-700 to-accent-blue-500 px-6 py-5 text-white shadow-2xl md:hidden">
                     <div className="absolute inset-0 bg-[radial-gradient(circle_at_20%_20%,rgba(255,255,255,0.2),transparent_35%)]" />
-                    <div className="relative flex flex-col gap-2">
-                        <span className="text-sm uppercase tracking-[0.18em] text-white/70">Today</span>
+                    <div className="relative flex flex-wrap items-center gap-x-3">
                         <span className="text-3xl font-semibold">Hello!</span>
-                        <span className="text-lg text-white/80">Loading your day...</span>
+                        <span className="text-3xl font-semibold text-white/70">Loading...</span>
                     </div>
                 </div>
                 <div className="hidden md:flex items-center justify-between gap-4 pt-1 pb-2 border-b border-(--surface-border)">
@@ -32,23 +31,16 @@ export default function HomeIntroduction({ skeleton, user, today }: Introduction
     return (
         <>
             {/* Mobile: full hero banner */}
-            <div className="relative overflow-hidden rounded-3xl bg-linear-to-r from-accent-blue-700 via-accent-blue-600 to-accent-blue-500 px-6 py-5 text-white shadow-2xl md:hidden">
+            <div className="relative overflow-hidden rounded-3xl bg-linear-to-r from-accent-blue-700 via-accent-blue-600 to-accent-blue-500 px-6 py-5 text-white shadow-2xl md:hidden mt-2">
                 <div className="absolute inset-0 bg-[radial-gradient(circle_at_15%_15%,rgba(255,255,255,0.25),transparent_35%)] opacity-80" />
                 <div className="absolute -right-6 -bottom-10 h-32 w-32 rounded-full bg-white/10 blur-3xl" />
-                <div className="relative flex flex-col gap-3">
-                    <div className="flex flex-col gap-1">
-                        <span className="text-sm uppercase tracking-[0.18em] text-white/70">Today</span>
-                        <span className="text-3xl font-semibold">
-                            Hello{hasName ? ` ${user.data.first}` : ""}!
-                        </span>
-                    </div>
-                    <a
-                        href={`/calendar?scope=today&view=week`}
-                        className="inline-flex w-fit items-center gap-2 rounded-2xl bg-white/12 px-3 py-1.5 text-base font-semibold text-white"
-                    >
-                        <span>{getNameByDate(activeDay.getDay() as DaysAsNumbers)},</span>
-                        <span>{getNameByMonth(activeDay.getMonth() as MonthsAsNumbers)} {getDateDD(activeDay)}</span>
-                    </a>
+                <div className="relative flex flex-wrap items-center gap-x-3">
+                    <span className="text-3xl font-semibold">
+                        Hello{hasName ? ` ${user.data.first}` : ""}!
+                    </span>
+                    <span className="text-3xl font-semibold text-white/70">
+                        {getNameByDate(activeDay.getDay() as DaysAsNumbers)}, {getNameByMonth(activeDay.getMonth() as MonthsAsNumbers)} {getDateDD(activeDay)}
+                    </span>
                 </div>
             </div>
 

--- a/packages/app/src/pages/(Home)/HomeIntroduction.tsx
+++ b/packages/app/src/pages/(Home)/HomeIntroduction.tsx
@@ -9,39 +9,66 @@ interface IntroductionParams {
 export default function HomeIntroduction({ skeleton, user, today }: IntroductionParams) {
     if (skeleton)
         return (
-            <div className="relative overflow-hidden rounded-3xl bg-linear-to-r from-accent-blue-700 to-accent-blue-500 px-6 py-5 text-white shadow-2xl">
-                <div className="absolute inset-0 bg-[radial-gradient(circle_at_20%_20%,rgba(255,255,255,0.2),transparent_35%)]" />
-                <div className="relative flex flex-col gap-2">
-                    <span className="text-sm uppercase tracking-[0.18em] text-white/70">Today</span>
-                    <span className="text-3xl font-semibold">Hello!</span>
-                    <span className="text-lg text-white/80">Loading your day...</span>
+            <>
+                <div className="relative overflow-hidden rounded-3xl bg-linear-to-r from-accent-blue-700 to-accent-blue-500 px-6 py-5 text-white shadow-2xl md:hidden">
+                    <div className="absolute inset-0 bg-[radial-gradient(circle_at_20%_20%,rgba(255,255,255,0.2),transparent_35%)]" />
+                    <div className="relative flex flex-col gap-2">
+                        <span className="text-sm uppercase tracking-[0.18em] text-white/70">Today</span>
+                        <span className="text-3xl font-semibold">Hello!</span>
+                        <span className="text-lg text-white/80">Loading your day...</span>
+                    </div>
                 </div>
-            </div>
+                <div className="hidden md:flex items-center justify-between gap-4 pt-1 pb-2 border-b border-(--surface-border)">
+                    <div className="flex flex-col gap-1">
+                        <div className="h-7 w-40 rounded-lg bg-silver-200 dark:bg-(--surface-raised) animate-pulse" />
+                        <div className="h-4 w-28 rounded bg-silver-200 dark:bg-(--surface-raised) animate-pulse" />
+                    </div>
+                </div>
+            </>
         )
 
     const hasName = user?.isSuccess && user.data.first;
     const activeDay = today || new Date();
     return (
-        <div className="relative overflow-hidden rounded-3xl bg-linear-to-r from-accent-blue-700 via-accent-blue-600 to-accent-blue-500 px-6 py-5 text-white shadow-2xl">
-            <div className="absolute inset-0 bg-[radial-gradient(circle_at_15%_15%,rgba(255,255,255,0.25),transparent_35%)] opacity-80" />
-            <div className="absolute -right-6 -bottom-10 h-32 w-32 rounded-full bg-white/10 blur-3xl" />
-            <div className="relative flex flex-col gap-3">
-                <div className="flex items-start justify-between ">
+        <>
+            {/* Mobile: full hero banner */}
+            <div className="relative overflow-hidden rounded-3xl bg-linear-to-r from-accent-blue-700 via-accent-blue-600 to-accent-blue-500 px-6 py-5 text-white shadow-2xl md:hidden">
+                <div className="absolute inset-0 bg-[radial-gradient(circle_at_15%_15%,rgba(255,255,255,0.25),transparent_35%)] opacity-80" />
+                <div className="absolute -right-6 -bottom-10 h-32 w-32 rounded-full bg-white/10 blur-3xl" />
+                <div className="relative flex flex-col gap-3">
                     <div className="flex flex-col gap-1">
                         <span className="text-sm uppercase tracking-[0.18em] text-white/70">Today</span>
                         <span className="text-3xl font-semibold">
                             Hello{hasName ? ` ${user.data.first}` : ""}!
                         </span>
                     </div>
+                    <a
+                        href={`/calendar?scope=today&view=week`}
+                        className="inline-flex w-fit items-center gap-2 rounded-2xl bg-white/12 px-3 py-1.5 text-base font-semibold text-white"
+                    >
+                        <span>{getNameByDate(activeDay.getDay() as DaysAsNumbers)},</span>
+                        <span>{getNameByMonth(activeDay.getMonth() as MonthsAsNumbers)} {getDateDD(activeDay)}</span>
+                    </a>
                 </div>
-                <a
-                    href={`/calendar?scope=today&view=week`}
-                    className="inline-flex w-fit items-center gap-2 rounded-2xl bg-white/12 px-3 py-1.5 text-base font-semibold text-white"
-                >
-                    <span>{getNameByDate(activeDay.getDay() as DaysAsNumbers)},</span>
-                    <span>{getNameByMonth(activeDay.getMonth() as MonthsAsNumbers)} {getDateDD(activeDay)}</span>
-                </a>
             </div>
-        </div>
+
+            {/* Desktop: compact header */}
+            <div className="hidden md:flex items-center justify-between gap-4 pt-1 pb-2 border-b border-(--surface-border)">
+                <div className="flex flex-col">
+                    <h1 className="text-2xl font-semibold text-primary">
+                        Hello{hasName ? `, ${user.data.first}` : ""}!
+                    </h1>
+                    <a
+                        href={`/calendar?scope=today&view=week`}
+                        className="text-sm text-muted hover:text-primary transition-colors"
+                    >
+                        {getNameByDate(activeDay.getDay() as DaysAsNumbers)}, {getNameByMonth(activeDay.getMonth() as MonthsAsNumbers)} {getDateDD(activeDay)}
+                    </a>
+                </div>
+                <span className="shrink-0 rounded-full bg-accent-blue/10 px-3 py-1 text-xs font-semibold text-accent-blue-700 dark:bg-(--accent-subtle) dark:text-accent-blue-300">
+                    Live sync
+                </span>
+            </div>
+        </>
     )
 }

--- a/packages/app/src/pages/(Layout)/(TaskInfoMenu)/MenuFields.tsx
+++ b/packages/app/src/pages/(Layout)/(TaskInfoMenu)/MenuFields.tsx
@@ -36,7 +36,7 @@ export default function MenuFields({
     return (
         <div className={`flex flex-col gap-4 ${isDeleting && "blur-xs"}`}>
             {type === "add" && (
-                <div className="flex flex-col gap-2 rounded-lg border border-accent-blue/15 bg-accent-blue-50/40 px-3 py-3 dark:bg-[rgba(99,102,241,0.12)]">
+                <div className="flex flex-col gap-2 rounded-lg border border-accent-blue/15 bg-accent-blue-50/40 px-3 py-3 dark:bg-(--accent-subtle)">
                     <div className="flex items-center justify-between">
                         <div className="flex flex-col">
                             <span className="text-sm font-semibold text-primary">Quick add</span>

--- a/packages/app/src/pages/(Layout)/(TaskInfoMenu)/MenuFields.tsx
+++ b/packages/app/src/pages/(Layout)/(TaskInfoMenu)/MenuFields.tsx
@@ -1,5 +1,6 @@
 import { formatDateTime } from "@/utils/date";
 import TaskInfoMenuItem from "./Shared/TaskInfoMenuItem";
+import DateTimePicker from "./Shared/DateTimePicker";
 import TaskInfoMenuUser from "./Shared/TaskInfoUser/TaskInfoMenuUser";
 import TaskInfoMenuTags from "./Shared/TaskInfoMenuTags";
 import TaskInfoMenuSelect from "./Shared/TaskInfoMenuSelect";
@@ -72,11 +73,9 @@ export default function MenuFields({
                         <div className="md:grid md:grid-cols-2 md:gap-4 flex flex-col gap-3">
                             <div className="flex flex-col gap-1">
                                 <label className="text-xs font-semibold text-primary px-1">Date &amp; Time</label>
-                                <input
-                                    type="datetime-local"
-                                    className="text-sm px-3 py-2 rounded-lg border border-accent-blue/30 bg-silver-200 text-primary shadow-inner focus:border-accent-blue focus:ring-2 focus:ring-accent-blue/30 focus:outline-hidden dark:bg-[#253350] dark:border-accent-blue/40"
+                                <DateTimePicker
                                     value={formatDateTime(tempData.date instanceof Date && tempData.date.getTime() > 0 ? tempData.date : new Date())}
-                                    onChange={(e) => setTempData({ date: new Date(e.target.value) })}
+                                    onChange={(val) => setTempData({ date: new Date(val) })}
                                 />
                             </div>
                             <TaskInfoMenuItem

--- a/packages/app/src/pages/(Layout)/(TaskInfoMenu)/Shared/DateTimePicker.tsx
+++ b/packages/app/src/pages/(Layout)/(TaskInfoMenu)/Shared/DateTimePicker.tsx
@@ -1,0 +1,238 @@
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+const DAY_NAMES = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
+const MONTH_NAMES = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+];
+
+function pad2(n: number) {
+  return String(n).padStart(2, "0");
+}
+
+function buildGrid(year: number, month: number): Array<Date | null> {
+  const first = new Date(year, month, 1);
+  const last = new Date(year, month + 1, 0);
+  const grid: Array<Date | null> = [];
+  for (let i = 0; i < first.getDay(); i++) grid.push(null);
+  for (let d = 1; d <= last.getDate(); d++) grid.push(new Date(year, month, d));
+  while (grid.length % 7 !== 0) grid.push(null);
+  return grid;
+}
+
+function toLocal(d: Date) {
+  return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}T${pad2(d.getHours())}:${pad2(d.getMinutes())}`;
+}
+
+interface DateTimePickerProps {
+  value: string;
+  onChange: (value: string) => void;
+  dateOnly?: boolean;
+  /** When true the calendar expands inline (pushes content down). Default: floating overlay via portal. */
+  inline?: boolean;
+}
+
+export default function DateTimePicker({ value, onChange, dateOnly = false, inline = false }: DateTimePickerProps) {
+  const [open, setOpen] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const [overlayStyle, setOverlayStyle] = useState<React.CSSProperties>({});
+
+  const parsed = value ? new Date(value) : null;
+  const isValid = !!parsed && !isNaN(parsed.getTime());
+
+  const now = new Date();
+  const [viewYear, setViewYear] = useState(isValid ? parsed!.getFullYear() : now.getFullYear());
+  const [viewMonth, setViewMonth] = useState(isValid ? parsed!.getMonth() : now.getMonth());
+
+  useEffect(() => {
+    if (isValid) {
+      setViewYear(parsed!.getFullYear());
+      setViewMonth(parsed!.getMonth());
+    }
+  }, [value]);
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (buttonRef.current?.contains(target)) return;
+      const overlay = document.getElementById("dtp-overlay");
+      if (overlay?.contains(target)) return;
+      setOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  const openPicker = () => {
+    if (!inline && buttonRef.current) {
+      const rect = buttonRef.current.getBoundingClientRect();
+      const PICKER_H = dateOnly ? 280 : 360;
+      const spaceBelow = window.innerHeight - rect.bottom - 8;
+      const top = spaceBelow >= PICKER_H ? rect.bottom + 4 : rect.top - PICKER_H - 4;
+      const left = Math.min(rect.left, window.innerWidth - 288 - 8);
+      setOverlayStyle({ position: "fixed", top, left, zIndex: 9999, width: 288 });
+    }
+    setOpen(v => !v);
+  };
+
+  const todayMidnight = new Date();
+  todayMidnight.setHours(0, 0, 0, 0);
+
+  const grid = buildGrid(viewYear, viewMonth);
+
+  const selHours = isValid ? parsed!.getHours() : 12;
+  const selMinutes = isValid ? parsed!.getMinutes() : 0;
+  const isPM = selHours >= 12;
+  const h12 = selHours % 12 || 12;
+
+  const displayLabel = isValid
+    ? dateOnly
+      ? parsed!.toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric", year: "numeric" })
+      : parsed!.toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric" }) +
+        "  ·  " +
+        parsed!.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" })
+    : "Pick a date…";
+
+  const pickDay = (day: Date) => {
+    if (dateOnly) {
+      onChange(`${day.getFullYear()}-${pad2(day.getMonth() + 1)}-${pad2(day.getDate())}`);
+      setOpen(false);
+      return;
+    }
+    const next = new Date(day);
+    next.setHours(selHours, selMinutes, 0, 0);
+    onChange(toLocal(next));
+  };
+
+  const updateTime = (h24: number, min: number) => {
+    const base = isValid ? new Date(parsed!) : new Date();
+    base.setHours(h24, min, 0, 0);
+    onChange(toLocal(base));
+  };
+
+  const prevMonth = () => {
+    if (viewMonth === 0) { setViewMonth(11); setViewYear(y => y - 1); }
+    else setViewMonth(m => m - 1);
+  };
+  const nextMonth = () => {
+    if (viewMonth === 11) { setViewMonth(0); setViewYear(y => y + 1); }
+    else setViewMonth(m => m + 1);
+  };
+
+  const pickerBody = (
+    <div
+      id={inline ? undefined : "dtp-overlay"}
+      className={`flex flex-col gap-3 rounded-xl border border-(--surface-border) bg-silver-50 dark:bg-[#121720] p-3 shadow-2xl ${inline ? "border-t border-accent-blue/20 rounded-t-none" : ""}`}
+    >
+      {/* Month navigation */}
+      <div className="flex items-center justify-between">
+        <button type="button" onClick={prevMonth}
+          className="rounded-lg px-2 py-1 text-sm text-muted hover:bg-(--surface-raised) hover:text-primary transition">
+          ←
+        </button>
+        <span className="text-sm font-semibold text-primary">
+          {MONTH_NAMES[viewMonth]} {viewYear}
+        </span>
+        <button type="button" onClick={nextMonth}
+          className="rounded-lg px-2 py-1 text-sm text-muted hover:bg-(--surface-raised) hover:text-primary transition">
+          →
+        </button>
+      </div>
+
+      {/* Day-name header */}
+      <div className="grid grid-cols-7 text-center">
+        {DAY_NAMES.map(d => (
+          <span key={d} className="text-[10px] font-bold text-muted">{d}</span>
+        ))}
+      </div>
+
+      {/* Day grid */}
+      <div className="grid grid-cols-7 gap-1.5">
+        {grid.map((day, i) => {
+          if (!day) return <div key={i} />;
+          const isSel = isValid &&
+            day.getFullYear() === parsed!.getFullYear() &&
+            day.getMonth() === parsed!.getMonth() &&
+            day.getDate() === parsed!.getDate();
+          const isTod = day.getTime() === todayMidnight.getTime();
+          return (
+            <button
+              key={i}
+              type="button"
+              onClick={() => pickDay(day)}
+              className={`mx-auto flex h-8 w-8 items-center justify-center rounded-full text-sm font-medium transition ${
+                isSel
+                  ? "bg-accent-blue text-white"
+                  : isTod
+                  ? "ring-1 ring-accent-blue text-accent-blue"
+                  : "text-primary hover:bg-(--surface-raised)"
+              }`}
+            >
+              {day.getDate()}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Time row */}
+      {!dateOnly && (
+        <div className="flex items-center justify-center gap-2 border-t border-(--surface-border) pt-3">
+          <input
+            type="number" min={1} max={12}
+            value={h12}
+            onChange={e => {
+              const h = Math.max(1, Math.min(12, Number(e.target.value)));
+              updateTime(isPM ? (h % 12) + 12 : h % 12, selMinutes);
+            }}
+            className="w-12 text-center text-sm font-semibold rounded-lg border border-(--surface-border) !bg-(--surface-raised) text-primary py-1.5 focus:outline-hidden focus:border-accent-blue"
+          />
+          <span className="text-sm font-bold text-muted">:</span>
+          <input
+            type="number" min={0} max={59}
+            value={pad2(selMinutes)}
+            onChange={e => {
+              const m = Math.max(0, Math.min(59, Number(e.target.value)));
+              updateTime(selHours, m);
+            }}
+            className="w-12 text-center text-sm font-semibold rounded-lg border border-(--surface-border) !bg-(--surface-raised) text-primary py-1.5 focus:outline-hidden focus:border-accent-blue"
+          />
+          <button
+            type="button"
+            onClick={() => updateTime(isPM ? selHours - 12 : selHours + 12, selMinutes)}
+            className="rounded-lg border border-(--surface-border) !bg-(--surface-raised) px-3 py-1.5 text-sm font-semibold text-primary hover:bg-(--accent-subtle) hover:text-accent-blue transition"
+          >
+            {isPM ? "PM" : "AM"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+
+  return (
+    <div className={`flex flex-col ${inline ? "rounded-lg border border-accent-blue/30 bg-silver-200 shadow-inner dark:bg-[#253350] dark:border-accent-blue/40 overflow-hidden" : "relative"}`}>
+      <button
+        ref={buttonRef}
+        type="button"
+        onClick={openPicker}
+        className={`flex items-center justify-between px-3 py-2 text-sm text-primary ${inline ? "" : "w-full rounded-lg border border-accent-blue/30 bg-silver-200 shadow-inner dark:bg-[#253350] dark:border-accent-blue/40 focus:border-accent-blue focus:ring-2 focus:ring-accent-blue/30 focus:outline-hidden"}`}
+      >
+        <span className={isValid ? "text-primary" : "text-muted"}>{displayLabel}</span>
+        <svg
+          className={`h-4 w-4 text-muted transition-transform duration-150 ${open ? "rotate-180" : ""}`}
+          viewBox="0 0 20 20" fill="currentColor"
+        >
+          <path fillRule="evenodd" d="M5.22 8.22a.75.75 0 0 1 1.06 0L10 11.94l3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.22 9.28a.75.75 0 0 1 0-1.06Z" clipRule="evenodd" />
+        </svg>
+      </button>
+
+      {open && inline && pickerBody}
+      {open && !inline && createPortal(
+        <div style={overlayStyle}>{pickerBody}</div>,
+        document.body
+      )}
+    </div>
+  );
+}

--- a/packages/app/src/pages/(Layout)/(TaskInfoMenu)/Shared/TaskInfoMenuItem.tsx
+++ b/packages/app/src/pages/(Layout)/(TaskInfoMenu)/Shared/TaskInfoMenuItem.tsx
@@ -1,4 +1,5 @@
 import { ChangeEventHandler } from "react";
+import DateTimePicker from "./DateTimePicker";
 
 export interface TaskInfoMenuItemOptions {
   type?: string;
@@ -42,15 +43,9 @@ export default function TaskInfoMenuItem({
     );
   } else if (type === "datetime-local") {
     inputPiece = (
-      <input
-        id={name.toLowerCase()}
-        name={name.toLowerCase()}
-        type={type}
-        className="text-base px-3 py-2 rounded-lg border border-accent-blue/30 bg-silver-200 text-primary shadow-inner focus:border-accent-blue focus:ring-2 focus:ring-accent-blue/30 focus:outline-hidden dark:bg-[#253350] dark:border-accent-blue/40"
-        placeholder={placeholder ?? `${name}...`}
-        value={value as any}
-        onChange={onChange}
-        autoFocus={false}
+      <DateTimePicker
+        value={value as string}
+        onChange={(val) => onChange?.({ target: { value: val } } as React.ChangeEvent<HTMLInputElement>)}
       />
     );
   }

--- a/packages/app/src/pages/(Layout)/(TaskInfoMenu)/Shared/TaskInfoMenuTags.tsx
+++ b/packages/app/src/pages/(Layout)/(TaskInfoMenu)/Shared/TaskInfoMenuTags.tsx
@@ -65,20 +65,20 @@ export default function TaskInfoMenuTags({
           </button>
         )}
       </div>
-      <div className="flex flex-wrap items-center gap-2 rounded-lg border border-accent-blue/20 bg-silver-200 p-2 shadow-inner focus-within:border-accent-blue dark:bg-[#253350]">
+      <div className="flex flex-wrap items-center gap-2 rounded-lg border border-accent-blue/20 bg-silver-200 p-2 shadow-inner focus-within:border-accent-blue dark:bg-(--surface-raised) dark:border-(--surface-border)">
         {tags.length === 0 && (
           <span className="text-sm text-muted px-1">No tags yet</span>
         )}
         {tags.map((tag) => (
           <span
             key={tag}
-            className="flex items-center gap-1 rounded-full bg-accent-blue/10 px-2 py-1 text-xs font-semibold text-accent-blue-800 ring-1 ring-accent-blue/20"
+            className="flex items-center gap-1 rounded-full bg-accent-blue/10 px-2 py-1 text-xs font-semibold text-accent-blue-800 ring-1 ring-accent-blue/20 dark:text-accent-blue-300 dark:ring-accent-blue/30"
           >
             <span>#{tag}</span>
             <button
               type="button"
               onClick={() => removeTag(tag)}
-              className="rounded-full p-0.5 text-accent-blue-700 hover:bg-accent-blue/20"
+              className="rounded-full p-0.5 text-accent-blue-700 hover:bg-accent-blue/20 dark:text-accent-blue-300"
             >
               <XMarkIcon className="h-4 w-4" />
             </button>
@@ -90,7 +90,7 @@ export default function TaskInfoMenuTags({
           onChange={(e) => setInput(e.target.value)}
           onKeyDown={handleKeyDown}
           onBlur={() => addTag(input)}
-          className="min-w-[120px] flex-1 border-none bg-transparent text-sm text-primary placeholder:text-slate-400 focus:outline-hidden"
+          className="min-w-[120px] flex-1 border-none !bg-transparent text-sm text-primary placeholder:text-slate-400 focus:outline-hidden"
           placeholder={tags.length === 0 ? "Add a tag…" : "Add another tag…"}
         />
       </div>

--- a/packages/app/src/pages/(Layout)/(TaskInfoMenu)/Shared/TaskInfoUser/TaskInfoMenuUser.tsx
+++ b/packages/app/src/pages/(Layout)/(TaskInfoMenu)/Shared/TaskInfoUser/TaskInfoMenuUser.tsx
@@ -45,7 +45,7 @@ export default function TaskInfoMenuUser({ data }: { data: Task }) {
                         const isSelf = host.data?.email === user.email;
 
                         return (
-                            <div key={key} className="flex flex-row items-center gap-2 rounded-xl border border-accent-blue/20 bg-accent-blue-50/50 px-3 py-2 dark:bg-[rgba(99,102,241,0.12)]">
+                            <div key={key} className="flex flex-row items-center gap-2 rounded-xl border border-accent-blue/20 bg-accent-blue-50/50 px-3 py-2 dark:bg-(--accent-subtle)">
                                 <div className="flex flex-col">
                                     <span className="text-sm font-semibold text-primary">{displayName}</span>
                                     <span className="text-xs text-muted">{user.email}</span>

--- a/packages/app/src/pages/(Layout)/DataContainer.tsx
+++ b/packages/app/src/pages/(Layout)/DataContainer.tsx
@@ -5,17 +5,17 @@ export default function DataContainer() {
     const isAuthRoute = location.pathname.startsWith("/auth");
 
     return (
-        <div className="relative min-h-screen">
-            <div className="absolute inset-0 transition-[background] duration-200" style={{ background: "var(--app-background)" }} />
-            <div className="relative z-10 min-h-screen flex flex-col md:ml-56 px-4 md:px-10 pt-2 md:pt-8">
-                <div
-                    id="unit-container"
-                    className={`flex flex-1 flex-col ${isAuthRoute ? "justify-center items-center" : "justify-start"} py-2 overflow-y-auto`}
-                    style={{ paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 1.5rem)" }}
-                >
-                    <Outlet />
-                </div>
+        <div
+            className="min-h-screen md:ml-56 flex flex-col"
+            style={{ background: "var(--app-background)", transition: "background 0.2s ease" }}
+        >
+            <div
+                id="unit-container"
+                className={`flex flex-1 flex-col ${isAuthRoute ? "justify-center items-center" : "justify-start"} px-4 md:px-6 pt-2 md:pt-8`}
+                style={{ paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 5.5rem)" }}
+            >
+                <Outlet />
             </div>
         </div>
-    )
+    );
 }

--- a/packages/app/src/pages/(Layout)/Nav/NavBar.tsx
+++ b/packages/app/src/pages/(Layout)/Nav/NavBar.tsx
@@ -54,7 +54,7 @@ export function NavBar() {
   );
 
   const renderSidebar = (isInteractive: boolean) => (
-    <div className="flex max-md:hidden fixed inset-y-0 left-0 w-56 flex-col z-40 border-r bg-silver-100 dark:bg-[#121720]" style={{ borderColor: "var(--surface-border)" }}>
+    <div className="flex max-md:hidden fixed inset-y-0 left-0 w-56 flex-col z-40 border-r bg-white dark:bg-(--surface-card)" style={{ borderColor: "var(--surface-border)" }}>
       {/* Logo */}
       <div className="flex items-center gap-3 px-4 py-5 border-b" style={{ borderColor: "var(--surface-border)" }}>
         <img src={icon} className="w-9 h-9 rounded-xl shadow-sm" />

--- a/packages/app/src/pages/(Layout)/Nav/NavItem.tsx
+++ b/packages/app/src/pages/(Layout)/Nav/NavItem.tsx
@@ -22,8 +22,8 @@ export default function NavItem({ to, title, children, disabled, sidebar }: NavI
                     disabled ? "pointer-events-none opacity-50" : ""
                 } ${
                     isActive
-                        ? "bg-accent-blue/10 text-accent-blue-700 fill-accent-blue-700 dark:bg-[rgba(99,102,241,0.18)]"
-                        : "text-muted fill-muted hover:text-primary hover:fill-primary hover:bg-silver-200 dark:hover:bg-vulcan-800"
+                        ? "bg-accent-blue/10 text-accent-blue-700 fill-accent-blue-700 dark:bg-(--accent-subtle)"
+                        : "text-muted fill-muted hover:text-primary hover:fill-primary hover:bg-silver-200 dark:hover:bg-(--surface-raised)"
                 }`}
             >
                 <div className="w-5 h-5 flex items-center justify-center flex-shrink-0">
@@ -47,8 +47,8 @@ export default function NavItem({ to, title, children, disabled, sidebar }: NavI
             <div
                 className={`flex items-center justify-center text-center w-11 h-11 rounded-2xl transition ${
                     isActive
-                        ? "bg-accent-blue-50/90 border border-accent-blue/30 shadow-[0_10px_24px_rgba(48,122,207,0.25)] dark:bg-[rgba(99,102,241,0.18)]"
-                        : "bg-transparent border border-transparent hover:border-accent-blue/20 hover:bg-accent-blue-50/60 dark:hover:bg-[rgba(99,102,241,0.12)]"
+                        ? "bg-accent-blue-50/90 border border-accent-blue/30 shadow-[0_10px_24px_rgba(48,122,207,0.25)] dark:bg-(--accent-subtle)"
+                        : "bg-transparent border border-transparent hover:border-accent-blue/20 hover:bg-accent-blue-50/60 dark:hover:bg-(--accent-subtle)"
                 }`}
             >
                 <div className="flex justify-center items-center w-full h-full p-1.5">

--- a/packages/app/src/pages/(Layout)/TaskInfoMenu.tsx
+++ b/packages/app/src/pages/(Layout)/TaskInfoMenu.tsx
@@ -340,7 +340,12 @@ export default function TaskInfoMenu({
     <>
       <Transition
         show={isOpen}
-        enter="transition duration-500"
+        enter="transition-opacity duration-200 ease-out"
+        enterFrom="opacity-0"
+        enterTo="opacity-100"
+        leave="transition-opacity duration-150 ease-in"
+        leaveFrom="opacity-100"
+        leaveTo="opacity-0"
       >
         <Dialog
           onClose={() => resetForm()}
@@ -348,9 +353,13 @@ export default function TaskInfoMenu({
           ref={ref}
           className="fixed inset-0 z-50"
         >
-          <div className="fixed inset-0 md:left-56 flex h-full">
-            <DialogPanel className="flex flex-1 min-w-0 flex-col overflow-y-auto text-primary p-6 md:p-10 bg-silver-50 dark:bg-[#121720]">
-              <div className="flex flex-col gap-4 w-full max-w-2xl mx-auto">
+          {/* Desktop backdrop */}
+          <div className="fixed inset-0 hidden md:block bg-slate-900/20 backdrop-blur-[1px]" aria-hidden="true" />
+
+          {/* Mobile: full screen. Desktop: right-side panel */}
+          <div className="fixed inset-0 md:inset-y-0 md:left-auto md:right-0 md:w-[520px] flex h-full z-10">
+            <DialogPanel className="flex flex-1 min-w-0 flex-col overflow-y-auto text-primary p-6 md:p-8 bg-silver-50 dark:bg-[#121720] md:border-l md:[box-shadow:-8px_0_40px_rgba(0,0,0,0.12)]" style={{ borderColor: "var(--surface-border)" }}>
+              <div className="flex flex-col gap-4 w-full max-w-2xl mx-auto md:max-w-none">
                 <MenuHeader
                   type={type!}
                   isDeleting={isDeleting}

--- a/packages/app/src/pages/(Settings)/UserLogin.tsx
+++ b/packages/app/src/pages/(Settings)/UserLogin.tsx
@@ -24,7 +24,7 @@ export default function UserLogin() {
                 <div className="flex flex-col gap-3">
                     <div className="flex items-center justify-between">
                         <h1 className="text-lg font-semibold text-primary">Sync Status</h1>
-                        <span className="text-xs rounded-full bg-accent-blue-50 px-2 py-1 text-accent-blue-700 dark:bg-[rgba(99,102,241,0.12)]">
+                        <span className="text-xs rounded-full bg-accent-blue-50 px-2 py-1 text-accent-blue-700 dark:bg-(--accent-subtle)">
                             {user.data?.id ? "Signed in" : "Signed out"}
                         </span>
                     </div>

--- a/packages/app/src/pages/Calendar.tsx
+++ b/packages/app/src/pages/Calendar.tsx
@@ -8,6 +8,22 @@ import { useApp } from "@/hooks/app";
 type Scope = "today" | "tomorrow" | "week" | "month" | "overdue" | "all";
 type ViewMode = "week" | "month";
 
+const MAX_WEEK_TASKS = 6;
+const MAX_MONTH_TASKS = 3;
+
+const DAY_NAMES = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+const hasTime = (task: Task) => {
+  const d = new Date(task.date);
+  return d.getHours() !== 0 || d.getMinutes() !== 0;
+};
+
+const formatTime = (task: Task) =>
+  new Date(task.date).toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
+
+const sortByTime = (list: Task[]) =>
+  [...list].sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+
 const startOfWeek = (reference: Date) => {
   const day = reference.getDay();
   const diff = (day === 0 ? -6 : 1) - day; // Monday start
@@ -196,14 +212,6 @@ export default function CalendarPage() {
     navigate(`/calendar?scope=week&view=week&week=${dayKey(next)}`, { replace: true });
   };
 
-  const goToWeek = (startDate: Date) => {
-    const startNormalized = startOfWeek(startDate);
-    setWeekStart(startNormalized);
-    setScope("week");
-    setView("week");
-    navigate(`/calendar?scope=week&view=week&week=${dayKey(startNormalized)}`, { replace: true });
-  };
-
   const changeMonth = (delta: number) => {
     const next = new Date(monthAnchor);
     next.setMonth(monthAnchor.getMonth() + delta);
@@ -250,270 +258,292 @@ export default function CalendarPage() {
   );
 
   const renderWeek = () => (
-    <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-7 gap-3">
-      {weekDays.map((day) => {
-        const key = dayKey(day);
-        const dayTasks = grouped[key] || [];
-        const isToday = dayKey(day) === dayKey(today);
-        return (
-          <div
-            key={key}
-            className="rounded-2xl surface-card border p-4 xl:p-3 shadow-xs"
-          >
-            <div className="flex xl:flex-col items-center xl:items-start justify-between xl:justify-start mb-3 xl:mb-2 gap-2">
-              <div
-                className={`flex h-9 w-9 xl:h-8 xl:w-8 shrink-0 items-center justify-center rounded-xl text-xs font-semibold ring-1 ${
+    <>
+      {/* ── Desktop: 7-column strip with vertical dividers ── */}
+      <div className="hidden md:grid md:grid-cols-7 md:grid-rows-1 md:flex-1 md:min-h-0 divide-x divide-(--surface-border) border border-(--surface-border) rounded-2xl overflow-hidden">
+        {weekDays.map((day) => {
+          const key = dayKey(day);
+          const dayTasks = sortByTime(grouped[key] || []);
+          const isToday = dayKey(day) === dayKey(today);
+          const visible = dayTasks.slice(0, MAX_WEEK_TASKS);
+          const overflow = dayTasks.length - MAX_WEEK_TASKS;
+
+          return (
+            <div key={key} className="flex flex-col">
+              {/* Column header */}
+              <div className={`flex flex-col shrink-0 items-center gap-1 px-2 py-3 border-b border-(--surface-border) ${isToday ? "bg-(--accent-subtle)" : ""}`}>
+                <span className={`text-[11px] font-semibold uppercase tracking-wider ${isToday ? "text-accent-blue" : "text-muted"}`}>
+                  {formatLabel(day, { weekday: "short" })}
+                </span>
+                <div className={`flex h-7 w-7 items-center justify-center rounded-lg text-sm font-bold ${
+                  isToday ? "bg-accent-blue-700 text-white" : "text-primary"
+                }`}>
+                  {day.getDate()}
+                </div>
+              </div>
+              {/* Tasks */}
+              <div className="flex flex-col flex-1 min-h-0 overflow-y-auto gap-2 p-2">
+                {visible.length === 0 && (
+                  <span className="text-center text-xs text-muted py-3">—</span>
+                )}
+                {visible.map((task) => (
+                  <button
+                    key={task.id ?? task.title}
+                    type="button"
+                    onClick={() => openTask(task, day)}
+                    className="flex flex-col items-start w-full rounded-lg bg-(--surface-card) border border-(--surface-border) px-2 py-1.5 text-left transition hover:border-accent-blue/40"
+                  >
+                    {hasTime(task) && (
+                      <span className="text-[10px] font-bold text-accent-blue leading-none mb-0.5">
+                        {formatTime(task)}
+                      </span>
+                    )}
+                    <span className="text-xs font-semibold text-primary leading-snug line-clamp-2">
+                      {task.title}
+                    </span>
+                    {task.priority ? (
+                      <span className="text-[10px] font-bold text-amber-500 mt-0.5">P{task.priority}</span>
+                    ) : null}
+                  </button>
+                ))}
+                {overflow > 0 && (
+                  <span className="text-xs font-semibold text-accent-blue px-1">+{overflow} more</span>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* ── Mobile: stacked day cards ── */}
+      <div className="md:hidden flex flex-col gap-3">
+        {weekDays.map((day) => {
+          const key = dayKey(day);
+          const dayTasks = grouped[key] || [];
+          const isToday = dayKey(day) === dayKey(today);
+          return (
+            <div key={key} className="rounded-2xl surface-card border p-4 shadow-xs">
+              <div className="flex items-center justify-between mb-3">
+                <div className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-xl text-xs font-semibold ring-1 ${
                   isToday
                     ? "bg-accent-blue/90 text-white ring-white/60 shadow-xs shadow-accent-blue/25"
-                    : "bg-slate-100 text-primary ring-slate-200 dark:bg-(--surface-raised) dark:text-primary dark:ring-(--surface-border)"
-                }`}
-              >
-                {formatLabel(day, { weekday: "short" })}
-              </div>
-              <div className="flex flex-col xl:mt-1.5">
-                <span className="text-sm xl:text-xs font-semibold text-primary">
-                  {formatLabel(day, { month: "short", day: "numeric" })}
-                </span>
-                <span className="text-xs text-muted xl:hidden">{dayTasks.length} pending</span>
-              </div>
-            </div>
-            <div className="flex flex-col gap-2 xl:gap-1.5">
-              {dayTasks.length === 0 && (
-                <div className="rounded-xl border border-dashed border-slate-200 bg-slate-50 px-3 py-2 xl:px-2 xl:py-1.5 text-xs text-muted dark:border-(--surface-border) dark:bg-(--surface-raised)">
-                  Nothing due.
+                    : "bg-slate-100 text-primary ring-slate-200 dark:bg-(--surface-raised) dark:ring-(--surface-border)"
+                }`}>
+                  {formatLabel(day, { weekday: "short" })}
                 </div>
-              )}
-              {dayTasks.map((task) => renderTask(task, day))}
+                <div className="flex flex-col text-right">
+                  <span className="text-sm font-semibold text-primary">{formatLabel(day, { month: "short", day: "numeric" })}</span>
+                  <span className="text-xs text-muted">{dayTasks.length} pending</span>
+                </div>
+              </div>
+              <div className="flex flex-col gap-2">
+                {dayTasks.length === 0 && (
+                  <div className="rounded-xl border border-dashed border-slate-200 bg-slate-50 px-3 py-2 text-xs text-muted dark:border-(--surface-border) dark:bg-(--surface-raised)">
+                    Nothing due.
+                  </div>
+                )}
+                {dayTasks.map((task) => renderTask(task, day))}
+              </div>
             </div>
-          </div>
-        );
-      })}
-    </div>
+          );
+        })}
+      </div>
+    </>
   );
 
   const renderMonth = () => (
-    <div className="flex flex-col gap-3">
-      <div className="flex md:hidden flex-wrap items-center justify-center gap-3">
-        <button
-          type="button"
-          onClick={() => changeMonth(-1)}
-          className="rounded-full surface-card border px-3 py-1.5 text-sm font-semibold text-primary shadow-xs transition hover:border-accent-blue/40"
-          aria-label="Previous month"
-        >
-          ←
-        </button>
-        <span className="text-lg font-semibold text-primary">
-          {formatLabel(monthAnchor, { month: "long", year: "numeric" })}
-        </span>
-        <button
-          type="button"
-          onClick={() => changeMonth(1)}
-          className="rounded-full surface-card border px-3 py-1.5 text-sm font-semibold text-primary shadow-xs transition hover:border-accent-blue/40"
-          aria-label="Next month"
-        >
-          →
-        </button>
-      </div>
-      <div className="flex flex-col gap-2">
-        {monthWeeks.map((week, idx) => (
-          <div
-            key={`week-${idx}-${week[0] ? week[0].toISOString() : idx}`}
-            role="button"
-            tabIndex={0}
-            onClick={() => week[0] && goToWeek(week[0])}
-            onKeyDown={(e) => {
-              if ((e.key === "Enter" || e.key === " ") && week[0]) {
-                e.preventDefault();
-                goToWeek(week[0]);
-              }
-            }}
-            className="grid grid-cols-7 gap-2 sm:gap-3 rounded-2xl surface-card border p-1 shadow-xs transition hover:border-accent-blue/40"
-          >
-            {week.map((day) => {
-              if (!day) {
-                return <div key={`empty-${Math.random()}`} className="flex flex-col rounded-xl border border-transparent p-1 sm:p-2" />;
-              }
-              const key = dayKey(day);
-              const dayTasks = grouped[key] || [];
-              const isToday = dayKey(day) === dayKey(today);
-              const isCurrentMonth = day.getMonth() === monthAnchor.getMonth();
-              return (
-                <div
-                  key={key}
-                  className={`flex flex-col rounded-xl border p-1 sm:p-2 ${
-                    isToday
-                      ? "border-accent-blue/50 ring-1 ring-accent-blue/20 bg-accent-blue-50/30 dark:bg-(--accent-subtle)"
-                      : "border-transparent"
-                  }`}
-                >
-                  <span
-                    className={`text-center text-xs sm:text-sm font-semibold ${isCurrentMonth ? "text-primary" : "text-muted/70"}`}
+    <>
+      {/* ── Desktop: full-page month grid ── */}
+      <div className="hidden md:flex md:flex-col border border-(--surface-border) rounded-2xl overflow-hidden">
+        {/* Day-name header */}
+        <div className="grid grid-cols-7 divide-x divide-(--surface-border) border-b border-(--surface-border)">
+          {DAY_NAMES.map((name) => (
+            <div key={name} className="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-muted text-center">
+              {name}
+            </div>
+          ))}
+        </div>
+        {/* Week rows */}
+        <div className="flex flex-col divide-y divide-(--surface-border)">
+          {monthWeeks.map((week, idx) => (
+            <div key={idx} className="grid grid-cols-7 divide-x divide-(--surface-border) min-h-[130px]">
+              {week.map((day, dayIdx) => {
+                if (!day) {
+                  return <div key={`empty-${idx}-${dayIdx}`} className="p-2 opacity-20 bg-(--app-background)" />;
+                }
+                const key = dayKey(day);
+                const dayTasks = grouped[key] || [];
+                const isToday = dayKey(day) === dayKey(today);
+                const isCurrentMonth = day.getMonth() === monthAnchor.getMonth();
+                const visible = dayTasks.slice(0, MAX_MONTH_TASKS);
+                const overflow = dayTasks.length - MAX_MONTH_TASKS;
+
+                return (
+                  <div
+                    key={key}
+                    className={`flex flex-col p-2 gap-1 ${!isCurrentMonth ? "opacity-40" : ""}`}
                   >
-                    {day.getDate()}
-                  </span>
-                  <div className="mt-1 flex flex-col gap-1">
-                    <span className="text-[10px] font-semibold text-muted sm:hidden">
-                      {dayTasks.length > 0 ? `${dayTasks.length} due` : "—"}
-                    </span>
-                    <div className="hidden sm:flex flex-col gap-1">
-                      {dayTasks.slice(0, 3).map((task) => (
-                        <button
-                          key={task.id ?? task.title}
-                          type="button"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            openTask(task, day);
-                          }}
-                          className="truncate rounded-lg bg-white/80 dark:bg-(--surface-raised) px-1.5 py-0.5 text-[10px] font-semibold text-primary shadow-xs transition"
-                        >
-                          {task.title}
-                        </button>
-                      ))}
-                      {dayTasks.length > 3 && (
-                        <span className="text-[10px] font-semibold text-accent-blue">+{dayTasks.length - 3} more</span>
-                      )}
-                      {dayTasks.length === 0 && <span className="text-[10px] text-muted">—</span>}
+                    <div className="flex justify-end mb-0.5">
+                      <span className={`flex h-6 w-6 items-center justify-center rounded-lg text-xs font-bold ${
+                        isToday ? "ring-2 ring-accent-blue/70 text-accent-blue" : "text-primary"
+                      }`}>
+                        {day.getDate()}
+                      </span>
                     </div>
+                    {visible.map((task) => (
+                      <button
+                        key={task.id ?? task.title}
+                        type="button"
+                        onClick={(e) => { e.stopPropagation(); openTask(task, day); }}
+                        className="truncate w-full text-left rounded-md bg-(--surface-raised) px-1.5 py-1 text-[11px] font-semibold text-primary transition hover:bg-(--accent-subtle) hover:text-accent-blue"
+                      >
+                        {hasTime(task) && (
+                          <span className="text-accent-blue mr-1">{formatTime(task)}</span>
+                        )}
+                        {task.title}
+                      </button>
+                    ))}
+                    {overflow > 0 && (
+                      <span className="text-[11px] font-semibold text-accent-blue pl-1">+{overflow} more</span>
+                    )}
                   </div>
-                </div>
-              );
-            })}
-          </div>
-        ))}
+                );
+              })}
+            </div>
+          ))}
+        </div>
       </div>
-    </div>
+
+      {/* ── Mobile: compact dot grid ── */}
+      <div className="md:hidden flex flex-col gap-3">
+        <div className="flex flex-wrap items-center justify-center gap-3">
+          <button type="button" onClick={() => changeMonth(-1)} className="rounded-full surface-card border px-3 py-1.5 text-sm font-semibold text-primary shadow-xs transition hover:border-accent-blue/40" aria-label="Previous month">←</button>
+          <span className="text-lg font-semibold text-primary">{formatLabel(monthAnchor, { month: "long", year: "numeric" })}</span>
+          <button type="button" onClick={() => changeMonth(1)} className="rounded-full surface-card border px-3 py-1.5 text-sm font-semibold text-primary shadow-xs transition hover:border-accent-blue/40" aria-label="Next month">→</button>
+        </div>
+        <div className="grid grid-cols-7 border-b border-(--surface-border) pb-1">
+          {DAY_NAMES.map((d) => (
+            <div key={d} className="text-center text-[10px] font-bold text-muted py-1">{d.slice(0, 1)}</div>
+          ))}
+        </div>
+        <div className="flex flex-col gap-1">
+          {monthWeeks.map((week, idx) => (
+            <div key={idx} className="grid grid-cols-7 gap-1">
+              {week.map((day, dayIdx) => {
+                if (!day) return <div key={`empty-${idx}-${dayIdx}`} />;
+                const key = dayKey(day);
+                const dayTasks = grouped[key] || [];
+                const isToday = dayKey(day) === dayKey(today);
+                const isCurrentMonth = day.getMonth() === monthAnchor.getMonth();
+                return (
+                  <button
+                    key={key}
+                    type="button"
+                    onClick={() => openTask(dayTasks[0] ?? { title: "", date: day, done: false, tags: [] } as Task, day)}
+                    className={`flex flex-col items-center rounded-xl border py-1.5 transition ${
+                      isToday ? "border-accent-blue/50 bg-(--accent-subtle)" : "border-transparent hover:bg-(--surface-raised)"
+                    } ${!isCurrentMonth ? "opacity-40" : ""}`}
+                  >
+                    <span className={`text-xs font-semibold ${isToday ? "text-accent-blue" : "text-primary"}`}>{day.getDate()}</span>
+                    {dayTasks.length > 0 && (
+                      <span className="text-[9px] font-bold text-muted leading-none">{dayTasks.length}</span>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+      </div>
+    </>
   );
 
   return (
-    <div className="w-full h-full flex flex-col px-3 md:px-0 py-4 pb-28 md:pb-4 gap-6">
-      <div className="flex w-full flex-col gap-3">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div className="flex flex-col">
-            <h1 className="text-2xl font-semibold text-primary">Calendar</h1>
-            <p className="text-sm text-muted md:hidden">See what is coming up this week or month.</p>
-          </div>
+    <div className="w-full flex flex-col flex-1 min-h-0 px-3 md:px-0 py-4 pb-28 md:pb-4 gap-4">
+      {/* ── Header row ── */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-col">
+          <h1 className="text-2xl font-semibold text-primary">Calendar</h1>
+          <p className="text-sm text-muted md:hidden">See what's coming up.</p>
+        </div>
 
-          {/* Desktop-only inline navigation */}
-          {view === "week" && (
-            <div className="hidden md:flex items-center gap-2">
-              <button
-                type="button"
-                onClick={() => changeWeek(-1)}
-                className="rounded-full surface-card border px-3 py-1.5 text-sm font-semibold text-primary shadow-xs transition hover:border-accent-blue/40"
-                aria-label="Previous week"
-              >
-                ←
-              </button>
+        {/* Desktop navigation */}
+        <div className="hidden md:flex items-center gap-2">
+          {view === "week" ? (
+            <>
+              <button type="button" onClick={() => changeWeek(-1)} className="rounded-full surface-card border px-3 py-1.5 text-sm font-semibold text-primary shadow-xs transition hover:border-accent-blue/40" aria-label="Previous week">←</button>
               <span className="min-w-[200px] text-center text-base font-semibold text-primary">
                 Week of {formatLabel(weekStart, { month: "long", day: "numeric" })}
               </span>
-              <button
-                type="button"
-                onClick={() => changeWeek(1)}
-                className="rounded-full surface-card border px-3 py-1.5 text-sm font-semibold text-primary shadow-xs transition hover:border-accent-blue/40"
-                aria-label="Next week"
-              >
-                →
-              </button>
-            </div>
-          )}
-          {view === "month" && (
-            <div className="hidden md:flex items-center gap-2">
-              <button
-                type="button"
-                onClick={() => changeMonth(-1)}
-                className="rounded-full surface-card border px-3 py-1.5 text-sm font-semibold text-primary shadow-xs transition hover:border-accent-blue/40"
-                aria-label="Previous month"
-              >
-                ←
-              </button>
+              <button type="button" onClick={() => changeWeek(1)} className="rounded-full surface-card border px-3 py-1.5 text-sm font-semibold text-primary shadow-xs transition hover:border-accent-blue/40" aria-label="Next week">→</button>
+            </>
+          ) : (
+            <>
+              <button type="button" onClick={() => changeMonth(-1)} className="rounded-full surface-card border px-3 py-1.5 text-sm font-semibold text-primary shadow-xs transition hover:border-accent-blue/40" aria-label="Previous month">←</button>
               <span className="min-w-[180px] text-center text-base font-semibold text-primary">
                 {formatLabel(monthAnchor, { month: "long", year: "numeric" })}
               </span>
-              <button
-                type="button"
-                onClick={() => changeMonth(1)}
-                className="rounded-full surface-card border px-3 py-1.5 text-sm font-semibold text-primary shadow-xs transition hover:border-accent-blue/40"
-                aria-label="Next month"
-              >
-                →
-              </button>
-            </div>
-          )}
-
-          <div className="flex items-center gap-2">
-            {(["week", "month"] as ViewMode[]).map((mode) => (
-              <button
-                key={mode}
-                type="button"
-                onClick={() => handleViewChange(mode)}
-                className={`rounded-full px-3 py-2 text-sm font-semibold shadow-xs transition ${view === mode ? "bg-accent-blue text-white shadow-accent-blue/30" : "surface-card border text-primary hover:-translate-y-px"}`}
-              >
-                {mode === "week" ? "Week view" : "Month view"}
-              </button>
-            ))}
-          </div>
-        </div>
-
-        {/* Mobile-only week navigation row */}
-        {view === "week" && (
-          <div className="flex md:hidden flex-wrap items-center justify-center gap-3">
-            <button
-              type="button"
-              onClick={() => changeWeek(-1)}
-              className="rounded-full surface-card border px-3 py-1.5 text-sm font-semibold text-primary shadow-xs transition hover:border-accent-blue/40"
-              aria-label="Previous week"
-            >
-              ←
-            </button>
-            <span className="text-lg font-semibold text-primary">
-              Week of {formatLabel(weekStart, { month: "long", day: "numeric" })}
-            </span>
-            <button
-              type="button"
-              onClick={() => changeWeek(1)}
-              className="rounded-full surface-card border px-3 py-1.5 text-sm font-semibold text-primary shadow-xs transition hover:border-accent-blue/40"
-              aria-label="Next week"
-            >
-              →
-            </button>
-          </div>
-        )}
-
-        {scope === "overdue" && (
-          <div className="rounded-2xl border border-red-200/70 bg-red-50/70 p-4 shadow-xs dark:border-red-400/50 dark:bg-[rgba(248,113,113,0.12)]">
-            <div className="flex items-center justify-between">
-              <div className="flex flex-col">
-                <span className="text-lg font-semibold text-red-700 dark:text-red-200">Overdue</span>
-                <span className="text-sm text-red-700/80 dark:text-red-200/80">Pending tasks before today</span>
-              </div>
-              <span className="text-2xl font-bold text-red-700 dark:text-red-200">{overdueList.length}</span>
-            </div>
-            <div className="mt-3 grid grid-cols-1 gap-2">
-              {overdueList.length === 0 && (
-                <div className="rounded-xl border border-dashed border-red-200 bg-white/70 px-3 py-2 text-sm text-red-700 dark:border-red-300/60 dark:bg-slate-900/60 dark:text-red-200">
-                  All caught up!
-                </div>
-              )}
-              {overdueList.map((task) => renderTask(task))}
-            </div>
-          </div>
-      )}
-
-        <div className="w-full">
-          {tasks.isLoading && (
-            <div className="rounded-2xl surface-card border p-4 text-sm text-muted shadow-xs">
-              Loading calendar...
-            </div>
-          )}
-          {tasks.isSuccess && (
-            <>
-              {view === "week" ? renderWeek() : renderMonth()}
-              <TaskInfoMenu type="edit" isOpen={isTaskMenuOpen} setIsOpen={setIsTaskMenuOpen} />
+              <button type="button" onClick={() => changeMonth(1)} className="rounded-full surface-card border px-3 py-1.5 text-sm font-semibold text-primary shadow-xs transition hover:border-accent-blue/40" aria-label="Next month">→</button>
             </>
           )}
         </div>
+
+        <div className="flex items-center gap-2">
+          {(["week", "month"] as ViewMode[]).map((mode) => (
+            <button
+              key={mode}
+              type="button"
+              onClick={() => handleViewChange(mode)}
+              className={`rounded-full px-3 py-2 text-sm font-semibold shadow-xs transition ${view === mode ? "bg-accent-blue text-white shadow-accent-blue/30" : "surface-card border text-primary hover:-translate-y-px"}`}
+            >
+              {mode === "week" ? "Week" : "Month"}
+            </button>
+          ))}
+        </div>
       </div>
+
+      {/* Mobile week navigation */}
+      {view === "week" && (
+        <div className="flex md:hidden flex-wrap items-center justify-center gap-3">
+          <button type="button" onClick={() => changeWeek(-1)} className="rounded-full surface-card border px-3 py-1.5 text-sm font-semibold text-primary shadow-xs transition hover:border-accent-blue/40" aria-label="Previous week">←</button>
+          <span className="text-base font-semibold text-primary">Week of {formatLabel(weekStart, { month: "long", day: "numeric" })}</span>
+          <button type="button" onClick={() => changeWeek(1)} className="rounded-full surface-card border px-3 py-1.5 text-sm font-semibold text-primary shadow-xs transition hover:border-accent-blue/40" aria-label="Next week">→</button>
+        </div>
+      )}
+
+      {/* Overdue banner */}
+      {scope === "overdue" && (
+        <div className="rounded-2xl border border-red-200/70 bg-red-50/70 p-4 shadow-xs dark:border-red-400/50 dark:bg-[rgba(248,113,113,0.12)]">
+          <div className="flex items-center justify-between">
+            <div className="flex flex-col">
+              <span className="text-lg font-semibold text-red-700 dark:text-red-200">Overdue</span>
+              <span className="text-sm text-red-700/80 dark:text-red-200/80">Pending tasks before today</span>
+            </div>
+            <span className="text-2xl font-bold text-red-700 dark:text-red-200">{overdueList.length}</span>
+          </div>
+          <div className="mt-3 grid grid-cols-1 gap-2">
+            {overdueList.length === 0 && (
+              <div className="rounded-xl border border-dashed border-red-200 bg-white/70 px-3 py-2 text-sm text-red-700 dark:border-red-300/60 dark:bg-(--surface-raised) dark:text-red-200">
+                All caught up!
+              </div>
+            )}
+            {overdueList.map((task) => renderTask(task))}
+          </div>
+        </div>
+      )}
+
+      {/* Calendar grid */}
+      {tasks.isLoading && (
+        <div className="rounded-2xl surface-card border p-4 text-sm text-muted shadow-xs">
+          Loading calendar...
+        </div>
+      )}
+      {tasks.isSuccess && (
+        <div className="flex flex-col flex-1 min-h-0 overflow-y-auto">
+          {view === "week" ? renderWeek() : renderMonth()}
+          <TaskInfoMenu type="edit" isOpen={isTaskMenuOpen} setIsOpen={setIsTaskMenuOpen} />
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/app/src/pages/Calendar.tsx
+++ b/packages/app/src/pages/Calendar.tsx
@@ -228,17 +228,17 @@ export default function CalendarPage() {
       key={task.id ?? task.title}
       type="button"
       onClick={() => openTask(task, day)}
-      className="flex flex-col rounded-xl surface-card border px-3 py-2 text-left shadow-xs transition hover:border-accent-blue/40"
+      className="flex flex-col rounded-xl surface-card border px-3 py-2 xl:px-2 xl:py-1.5 text-left shadow-xs transition hover:border-accent-blue/40"
     >
-      <div className="flex items-center justify-between">
-        <span className="text-sm font-semibold text-primary">{task.title}</span>
-        {task.priority ? <span className="text-[11px] font-semibold text-amber-600">P{task.priority}</span> : null}
+      <div className="flex items-center justify-between gap-1">
+        <span className="text-sm xl:text-xs font-semibold text-primary xl:truncate">{task.title}</span>
+        {task.priority ? <span className="text-[11px] font-semibold text-amber-600 shrink-0">P{task.priority}</span> : null}
       </div>
       {task.description ? (
-        <p className="mt-1 text-xs text-muted line-clamp-2">{task.description}</p>
+        <p className="mt-1 text-xs text-muted line-clamp-2 xl:hidden">{task.description}</p>
       ) : null}
       {Array.isArray(task.tags) && task.tags.length > 0 && (
-        <div className="mt-2 flex flex-wrap gap-2">
+        <div className="mt-2 flex flex-wrap gap-2 xl:hidden">
           {task.tags.map((tag) => (
             <span key={String(tag)} className="rounded-full bg-accent-blue/10 px-2 py-1 text-[11px] font-semibold uppercase tracking-wide text-accent-blue-800 ring-1 ring-accent-blue/20">
               #{tag}
@@ -250,7 +250,7 @@ export default function CalendarPage() {
   );
 
   const renderWeek = () => (
-    <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+    <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-7 gap-3">
       {weekDays.map((day) => {
         const key = dayKey(day);
         const dayTasks = grouped[key] || [];
@@ -258,30 +258,28 @@ export default function CalendarPage() {
         return (
           <div
             key={key}
-            className="rounded-2xl surface-card border p-4 shadow-xs"
+            className="rounded-2xl surface-card border p-4 xl:p-3 shadow-xs"
           >
-            <div className="flex items-center justify-between mb-3">
-              <div className="flex items-center gap-3">
-                <div
-                  className={`flex h-10 w-10 items-center justify-center rounded-xl text-sm font-semibold ring-1 ${
-                    isToday
-                      ? "bg-accent-blue/90 text-white ring-white/60 shadow-xs shadow-accent-blue/25"
-                      : "bg-slate-100 text-primary ring-slate-200 dark:bg-slate-800 dark:text-white dark:ring-slate-700"
-                  }`}
-                >
-                  {formatLabel(day, { weekday: "short" })}
-                </div>
-                <div className="flex flex-col">
-                  <span className="text-sm font-semibold text-primary">
-                    {formatLabel(day, { month: "long", day: "numeric" })}
-                  </span>
-                  <span className="text-xs text-muted">{dayTasks.length} pending</span>
-                </div>
+            <div className="flex xl:flex-col items-center xl:items-start justify-between xl:justify-start mb-3 xl:mb-2 gap-2">
+              <div
+                className={`flex h-9 w-9 xl:h-8 xl:w-8 shrink-0 items-center justify-center rounded-xl text-xs font-semibold ring-1 ${
+                  isToday
+                    ? "bg-accent-blue/90 text-white ring-white/60 shadow-xs shadow-accent-blue/25"
+                    : "bg-slate-100 text-primary ring-slate-200 dark:bg-(--surface-raised) dark:text-primary dark:ring-(--surface-border)"
+                }`}
+              >
+                {formatLabel(day, { weekday: "short" })}
+              </div>
+              <div className="flex flex-col xl:mt-1.5">
+                <span className="text-sm xl:text-xs font-semibold text-primary">
+                  {formatLabel(day, { month: "short", day: "numeric" })}
+                </span>
+                <span className="text-xs text-muted xl:hidden">{dayTasks.length} pending</span>
               </div>
             </div>
-            <div className="flex flex-col gap-2">
+            <div className="flex flex-col gap-2 xl:gap-1.5">
               {dayTasks.length === 0 && (
-                <div className="rounded-xl border border-dashed border-slate-200 bg-slate-50 px-3 py-2 text-xs text-muted dark:border-slate-700 dark:bg-slate-800/60">
+                <div className="rounded-xl border border-dashed border-slate-200 bg-slate-50 px-3 py-2 xl:px-2 xl:py-1.5 text-xs text-muted dark:border-(--surface-border) dark:bg-(--surface-raised)">
                   Nothing due.
                 </div>
               )}
@@ -295,7 +293,7 @@ export default function CalendarPage() {
 
   const renderMonth = () => (
     <div className="flex flex-col gap-3">
-      <div className="flex flex-wrap items-center justify-center gap-3">
+      <div className="flex md:hidden flex-wrap items-center justify-center gap-3">
         <button
           type="button"
           onClick={() => changeMonth(-1)}
@@ -344,7 +342,7 @@ export default function CalendarPage() {
                   key={key}
                   className={`flex flex-col rounded-xl border p-1 sm:p-2 ${
                     isToday
-                      ? "border-accent-blue/50 ring-1 ring-accent-blue/20 bg-accent-blue-50/30 dark:bg-[rgba(99,102,241,0.1)]"
+                      ? "border-accent-blue/50 ring-1 ring-accent-blue/20 bg-accent-blue-50/30 dark:bg-(--accent-subtle)"
                       : "border-transparent"
                   }`}
                 >
@@ -366,7 +364,7 @@ export default function CalendarPage() {
                             e.stopPropagation();
                             openTask(task, day);
                           }}
-                          className="truncate rounded-lg bg-white/80 dark:bg-slate-800 px-1.5 py-0.5 text-[10px] font-semibold text-primary shadow-xs transition"
+                          className="truncate rounded-lg bg-white/80 dark:bg-(--surface-raised) px-1.5 py-0.5 text-[10px] font-semibold text-primary shadow-xs transition"
                         >
                           {task.title}
                         </button>
@@ -387,13 +385,62 @@ export default function CalendarPage() {
   );
 
   return (
-    <div className="w-full h-full flex flex-col px-3 md:px-6 lg:px-10 py-4 pb-28 gap-6">
-      <div className="flex w-full max-w-5xl flex-col gap-3 mx-auto">
+    <div className="w-full h-full flex flex-col px-3 md:px-0 py-4 pb-28 md:pb-4 gap-6">
+      <div className="flex w-full flex-col gap-3">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div className="flex flex-col">
             <h1 className="text-2xl font-semibold text-primary">Calendar</h1>
-            <p className="text-sm text-muted">See what is coming up this week or month.</p>
+            <p className="text-sm text-muted md:hidden">See what is coming up this week or month.</p>
           </div>
+
+          {/* Desktop-only inline navigation */}
+          {view === "week" && (
+            <div className="hidden md:flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => changeWeek(-1)}
+                className="rounded-full surface-card border px-3 py-1.5 text-sm font-semibold text-primary shadow-xs transition hover:border-accent-blue/40"
+                aria-label="Previous week"
+              >
+                ←
+              </button>
+              <span className="min-w-[200px] text-center text-base font-semibold text-primary">
+                Week of {formatLabel(weekStart, { month: "long", day: "numeric" })}
+              </span>
+              <button
+                type="button"
+                onClick={() => changeWeek(1)}
+                className="rounded-full surface-card border px-3 py-1.5 text-sm font-semibold text-primary shadow-xs transition hover:border-accent-blue/40"
+                aria-label="Next week"
+              >
+                →
+              </button>
+            </div>
+          )}
+          {view === "month" && (
+            <div className="hidden md:flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => changeMonth(-1)}
+                className="rounded-full surface-card border px-3 py-1.5 text-sm font-semibold text-primary shadow-xs transition hover:border-accent-blue/40"
+                aria-label="Previous month"
+              >
+                ←
+              </button>
+              <span className="min-w-[180px] text-center text-base font-semibold text-primary">
+                {formatLabel(monthAnchor, { month: "long", year: "numeric" })}
+              </span>
+              <button
+                type="button"
+                onClick={() => changeMonth(1)}
+                className="rounded-full surface-card border px-3 py-1.5 text-sm font-semibold text-primary shadow-xs transition hover:border-accent-blue/40"
+                aria-label="Next month"
+              >
+                →
+              </button>
+            </div>
+          )}
+
           <div className="flex items-center gap-2">
             {(["week", "month"] as ViewMode[]).map((mode) => (
               <button
@@ -408,8 +455,9 @@ export default function CalendarPage() {
           </div>
         </div>
 
+        {/* Mobile-only week navigation row */}
         {view === "week" && (
-          <div className="flex flex-wrap items-center justify-center gap-3">
+          <div className="flex md:hidden flex-wrap items-center justify-center gap-3">
             <button
               type="button"
               onClick={() => changeWeek(-1)}

--- a/packages/app/src/pages/Calendar.tsx
+++ b/packages/app/src/pages/Calendar.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 import { useTasks, Task } from "@/hooks/tasks";
 import { occursOnDate, isTaskDone } from "@/utils/data";
@@ -189,6 +189,24 @@ export default function CalendarPage() {
     return weeks;
   }, [monthDays]);
 
+  const [windowH, setWindowH] = useState(() =>
+    typeof window !== "undefined" ? window.innerHeight : 932
+  );
+  useEffect(() => {
+    const handler = () => setWindowH(window.innerHeight);
+    window.addEventListener("resize", handler);
+    return () => window.removeEventListener("resize", handler);
+  }, []);
+
+  // ~300px accounts for: DataContainer top/bottom padding, Calendar py/pb, header row,
+  // month nav, day-name labels, and gaps. Keeps pill count accurate across device sizes.
+  const maxMobileTasks = useMemo(() => {
+    const gridH = windowH - 250;
+    const rowH = Math.max(40, gridH / monthWeeks.length);
+    // 34 = date number (18px) + overflow label (16px); 17 = pill (16px) + gap (1px)
+    return Math.max(1, Math.floor((rowH - 34) / 17));
+  }, [windowH, monthWeeks.length]);
+
   const overdueList = useMemo(() => {
     if (!tasks.data) return [];
     return tasks.data.filter((task) => isOverdue(task, today));
@@ -317,35 +335,51 @@ export default function CalendarPage() {
         })}
       </div>
 
-      {/* ── Mobile: stacked day cards ── */}
-      <div className="md:hidden flex flex-col gap-3">
-        {weekDays.map((day) => {
+      {/* ── Mobile: compact day list ── */}
+      <div className="md:hidden rounded-2xl surface-card border overflow-hidden shadow-xs">
+        {weekDays.map((day, idx) => {
           const key = dayKey(day);
-          const dayTasks = grouped[key] || [];
+          const dayTasks = sortByTime(grouped[key] || []);
           const isToday = dayKey(day) === dayKey(today);
+          const overflow = dayTasks.length - 3;
           return (
-            <div key={key} className="rounded-2xl surface-card border p-4 shadow-xs">
-              <div className="flex items-center justify-between mb-3">
-                <div className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-xl text-xs font-semibold ring-1 ${
-                  isToday
-                    ? "bg-accent-blue/90 text-white ring-white/60 shadow-xs shadow-accent-blue/25"
-                    : "bg-slate-100 text-primary ring-slate-200 dark:bg-(--surface-raised) dark:ring-(--surface-border)"
-                }`}>
+            <div key={key} className={idx > 0 ? "border-t border-(--surface-border)" : ""}>
+              <div className={`flex items-center gap-3 px-4 py-2.5 ${isToday ? "bg-(--accent-subtle)" : ""}`}>
+                <span className={`shrink-0 w-8 text-xs font-bold ${isToday ? "text-accent-blue" : "text-muted"}`}>
                   {formatLabel(day, { weekday: "short" })}
-                </div>
-                <div className="flex flex-col text-right">
-                  <span className="text-sm font-semibold text-primary">{formatLabel(day, { month: "short", day: "numeric" })}</span>
-                  <span className="text-xs text-muted">{dayTasks.length} pending</span>
-                </div>
-              </div>
-              <div className="flex flex-col gap-2">
-                {dayTasks.length === 0 && (
-                  <div className="rounded-xl border border-dashed border-slate-200 bg-slate-50 px-3 py-2 text-xs text-muted dark:border-(--surface-border) dark:bg-(--surface-raised)">
-                    Nothing due.
-                  </div>
+                </span>
+                <span className={`text-sm font-semibold ${isToday ? "text-accent-blue" : "text-primary"}`}>
+                  {formatLabel(day, { month: "short", day: "numeric" })}
+                </span>
+                {dayTasks.length > 0 && (
+                  <span className="ml-auto shrink-0 rounded-full bg-accent-blue/10 px-2 py-0.5 text-[11px] font-bold text-accent-blue-700 dark:bg-(--accent-subtle) dark:text-accent-blue-300">
+                    {dayTasks.length}
+                  </span>
                 )}
-                {dayTasks.map((task) => renderTask(task, day))}
               </div>
+              {dayTasks.length > 0 && (
+                <div className="flex flex-col px-4 pb-2.5 pt-0.5 gap-0.5">
+                  {dayTasks.slice(0, 3).map((task) => (
+                    <button
+                      key={task.id ?? task.title}
+                      type="button"
+                      onClick={() => openTask(task, day)}
+                      className="flex items-center gap-2 w-full py-0.5 text-left"
+                    >
+                      {hasTime(task) && (
+                        <span className="shrink-0 text-[10px] font-bold text-accent-blue">{formatTime(task)}</span>
+                      )}
+                      <span className="flex-1 min-w-0 text-sm text-primary truncate">{task.title}</span>
+                      {task.priority ? (
+                        <span className="shrink-0 text-xs font-bold text-amber-500">{"!".repeat(task.priority)}</span>
+                      ) : null}
+                    </button>
+                  ))}
+                  {overflow > 0 && (
+                    <span className="text-xs font-semibold text-accent-blue pt-0.5">+{overflow} more</span>
+                  )}
+                </div>
+              )}
             </div>
           );
         })}
@@ -416,41 +450,57 @@ export default function CalendarPage() {
         </div>
       </div>
 
-      {/* ── Mobile: compact dot grid ── */}
-      <div className="md:hidden flex flex-col gap-3">
-        <div className="flex flex-wrap items-center justify-center gap-3">
+      {/* ── Mobile: full-height dot grid ── */}
+      <div className="md:hidden flex flex-col flex-1 min-h-0 gap-2 w-screen -ml-7 px-1.5">
+        <div className="flex flex-wrap items-center justify-center gap-3 shrink-0 px-7">
           <button type="button" onClick={() => changeMonth(-1)} className="rounded-full surface-card border px-3 py-1.5 text-sm font-semibold text-primary shadow-xs transition hover:border-accent-blue/40" aria-label="Previous month">←</button>
           <span className="text-lg font-semibold text-primary">{formatLabel(monthAnchor, { month: "long", year: "numeric" })}</span>
           <button type="button" onClick={() => changeMonth(1)} className="rounded-full surface-card border px-3 py-1.5 text-sm font-semibold text-primary shadow-xs transition hover:border-accent-blue/40" aria-label="Next month">→</button>
         </div>
-        <div className="grid grid-cols-7 border-b border-(--surface-border) pb-1">
+        <div className="grid grid-cols-7 shrink-0 border-b border-(--surface-border) pb-1">
           {DAY_NAMES.map((d) => (
             <div key={d} className="text-center text-[10px] font-bold text-muted py-1">{d.slice(0, 1)}</div>
           ))}
         </div>
-        <div className="flex flex-col gap-1">
+        <div
+          className="grid flex-1 min-h-0"
+          style={{ gridTemplateRows: `repeat(${monthWeeks.length}, 1fr)` }}
+        >
           {monthWeeks.map((week, idx) => (
-            <div key={idx} className="grid grid-cols-7 gap-1">
+            <div key={idx} className="flex flex-row">
               {week.map((day, dayIdx) => {
-                if (!day) return <div key={`empty-${idx}-${dayIdx}`} />;
+                if (!day) return <div key={`empty-${idx}-${dayIdx}`} className="flex-1" />;
                 const key = dayKey(day);
-                const dayTasks = grouped[key] || [];
+                const dayTasks = sortByTime(grouped[key] || []);
                 const isToday = dayKey(day) === dayKey(today);
                 const isCurrentMonth = day.getMonth() === monthAnchor.getMonth();
+                const overflow = dayTasks.length - maxMobileTasks;
                 return (
-                  <button
+                  <div
                     key={key}
-                    type="button"
-                    onClick={() => openTask(dayTasks[0] ?? { title: "", date: day, done: false, tags: [] } as Task, day)}
-                    className={`flex flex-col items-center rounded-xl border py-1.5 transition ${
-                      isToday ? "border-accent-blue/50 bg-(--accent-subtle)" : "border-transparent hover:bg-(--surface-raised)"
+                    className={`flex flex-col flex-1 overflow-hidden pt-1 ${
+                      isToday ? "bg-(--accent-subtle)" : ""
                     } ${!isCurrentMonth ? "opacity-40" : ""}`}
                   >
-                    <span className={`text-xs font-semibold ${isToday ? "text-accent-blue" : "text-primary"}`}>{day.getDate()}</span>
-                    {dayTasks.length > 0 && (
-                      <span className="text-[9px] font-bold text-muted leading-none">{dayTasks.length}</span>
-                    )}
-                  </button>
+                    <span className={`text-center text-xs font-semibold leading-none mb-1 shrink-0 block ${isToday ? "text-accent-blue" : "text-primary"}`}>
+                      {day.getDate()}
+                    </span>
+                    <div className="flex-1 flex flex-col gap-px px-0.5 min-h-0">
+                      {dayTasks.slice(0, maxMobileTasks).map((task) => (
+                        <button
+                          key={task.id ?? task.title}
+                          type="button"
+                          onClick={(e) => { e.stopPropagation(); openTask(task, day); }}
+                          className="w-full shrink-0 text-left truncate rounded-sm bg-accent-blue px-1 text-[9px] font-bold text-white leading-[1.5] py-px"
+                        >
+                          {task.title}
+                        </button>
+                      ))}
+                      {overflow > 0 && (
+                        <span className="mt-auto text-[11px] font-bold text-accent-blue pl-0.5 pb-0.5 block">+{overflow} more</span>
+                      )}
+                    </div>
+                  </div>
                 );
               })}
             </div>
@@ -541,7 +591,7 @@ export default function CalendarPage() {
         </div>
       )}
       {tasks.isSuccess && (
-        <div className="flex flex-col flex-1 min-h-0 overflow-y-auto">
+        <div className="flex flex-col flex-1 min-h-0">
           {view === "week" ? renderWeek() : renderMonth()}
           <TaskInfoMenu type="edit" isOpen={isTaskMenuOpen} setIsOpen={setIsTaskMenuOpen} />
         </div>

--- a/packages/app/src/pages/Calendar.tsx
+++ b/packages/app/src/pages/Calendar.tsx
@@ -291,19 +291,21 @@ export default function CalendarPage() {
                     key={task.id ?? task.title}
                     type="button"
                     onClick={() => openTask(task, day)}
-                    className="flex flex-col items-start w-full rounded-lg bg-(--surface-card) border border-(--surface-border) px-2 py-1.5 text-left transition hover:border-accent-blue/40"
+                    className="relative flex flex-col items-start w-full rounded-lg bg-(--surface-card) border border-(--surface-border) px-2 py-1.5 text-left transition hover:border-accent-blue/40"
                   >
+                    {task.priority ? (
+                      <span className="absolute top-1 right-1 text-[10px] font-bold text-amber-500 leading-none">
+                        {"!".repeat(task.priority)}
+                      </span>
+                    ) : null}
                     {hasTime(task) && (
                       <span className="text-[10px] font-bold text-accent-blue leading-none mb-0.5">
                         {formatTime(task)}
                       </span>
                     )}
-                    <span className="text-xs font-semibold text-primary leading-snug line-clamp-2">
+                    <span className="text-xs font-semibold text-primary leading-snug line-clamp-2 pr-3">
                       {task.title}
                     </span>
-                    {task.priority ? (
-                      <span className="text-[10px] font-bold text-amber-500 mt-0.5">P{task.priority}</span>
-                    ) : null}
                   </button>
                 ))}
                 {overflow > 0 && (

--- a/packages/app/src/pages/Home.tsx
+++ b/packages/app/src/pages/Home.tsx
@@ -6,6 +6,7 @@ import AuthProvider from "./Auth/AuthProvider";
 import HomeIntroduction from "./(Home)/HomeIntroduction";
 import HomeAgenda from "./(Home)/HomeAgenda";
 import HomeUpcoming from "./(Home)/HomeUpcoming";
+import HomeAnnouncements from "./(Home)/HomeAnnouncements";
 
 const Home = () => {
     const auth = useAuth();
@@ -20,22 +21,28 @@ const Home = () => {
 
     if (auth.isLoading)
         return (
-            <div className="w-full h-full flex flex-col px-2 md:px-4 lg:px-6 pb-20">
-                <div className="mx-auto flex w-full max-w-4xl flex-col gap-6">
-                    <HomeIntroduction skeleton={true} />
-                    <HomeAgenda skeleton={true} />
-                    <HomeUpcoming skeleton={true} />
+            <div className="w-full flex flex-col pb-24 md:pb-4">
+                <div className="w-full flex flex-col gap-6 md:grid md:grid-cols-[1fr_300px] md:items-start">
+                    <div className="flex flex-col gap-6">
+                        <HomeIntroduction skeleton={true} />
+                        <HomeAgenda skeleton={true} />
+                        <HomeUpcoming skeleton={true} />
+                    </div>
+                    <div />
                 </div>
             </div>
         )
 
     return (
         <AuthProvider>
-            <div className="w-full h-full flex flex-col px-2 md:px-4 lg:px-6 pb-20">
-                <div className="mx-auto flex w-full max-w-4xl flex-col gap-6">
-                    <HomeIntroduction user={user} today={today} />
-                    <HomeAgenda />
-                    <HomeUpcoming />
+            <div className="w-full flex flex-col pb-24 md:pb-4">
+                <div className="w-full flex flex-col gap-6 md:grid md:grid-cols-[1fr_300px] md:items-start">
+                    <div className="flex flex-col gap-6">
+                        <HomeIntroduction user={user} today={today} />
+                        <HomeAgenda />
+                        <HomeUpcoming />
+                    </div>
+                    <HomeAnnouncements />
                 </div>
             </div>
         </AuthProvider>

--- a/packages/app/src/pages/Settings.tsx
+++ b/packages/app/src/pages/Settings.tsx
@@ -369,7 +369,7 @@ export default function SettingsPage() {
     <button
       type="button"
       onClick={() => toggleSection(id)}
-      className="flex w-full items-center justify-between gap-3 px-4 py-3.5 text-left bg-silver-200 dark:bg-vulcan-800 hover:bg-silver-300 dark:hover:bg-vulcan-700 transition-colors"
+      className="flex w-full items-center justify-between gap-3 px-4 py-3.5 text-left bg-silver-200 dark:bg-(--surface-raised) hover:bg-silver-300 dark:hover:bg-(--surface-card) transition-colors"
     >
       <div className="flex min-w-0 flex-1 flex-col gap-0.5">
         <div className="flex items-center gap-2">
@@ -426,7 +426,7 @@ export default function SettingsPage() {
                 type="text"
                 value={profileForm.first}
                 onChange={(e) => setProfileForm({ ...profileForm, first: e.target.value })}
-                className="rounded-lg border border-(--surface-border) bg-silver-200 dark:bg-vulcan-950 px-3 py-2 text-sm text-primary focus:border-accent-blue focus:outline-hidden"
+                className="rounded-lg border border-(--surface-border) bg-silver-200 dark:bg-(--surface-raised) px-3 py-2 text-sm text-primary focus:border-accent-blue focus:outline-hidden"
               />
             </label>
             <label className="flex flex-col gap-1 text-sm text-primary">
@@ -435,7 +435,7 @@ export default function SettingsPage() {
                 type="text"
                 value={profileForm.last}
                 onChange={(e) => setProfileForm({ ...profileForm, last: e.target.value })}
-                className="rounded-lg border border-(--surface-border) bg-silver-200 dark:bg-vulcan-950 px-3 py-2 text-sm text-primary focus:border-accent-blue focus:outline-hidden"
+                className="rounded-lg border border-(--surface-border) bg-silver-200 dark:bg-(--surface-raised) px-3 py-2 text-sm text-primary focus:border-accent-blue focus:outline-hidden"
               />
             </label>
             <label className="flex flex-col gap-1 text-sm text-primary md:col-span-2">
@@ -444,7 +444,7 @@ export default function SettingsPage() {
                 type="email"
                 value={profileForm.email}
                 onChange={(e) => setProfileForm({ ...profileForm, email: e.target.value })}
-                className="rounded-lg border border-(--surface-border) bg-silver-200 dark:bg-vulcan-950 px-3 py-2 text-sm text-primary focus:border-accent-blue focus:outline-hidden"
+                className="rounded-lg border border-(--surface-border) bg-silver-200 dark:bg-(--surface-raised) px-3 py-2 text-sm text-primary focus:border-accent-blue focus:outline-hidden"
               />
             </label>
             <div className="flex flex-wrap items-center gap-2 md:col-span-2">
@@ -458,7 +458,7 @@ export default function SettingsPage() {
               <button
                 type="button"
                 onClick={() => { setShowChangePassword(true); setPasswordMessage(""); }}
-                className="rounded-lg border border-(--surface-border) bg-silver-200 dark:bg-vulcan-800 px-3 py-2 text-sm font-semibold text-primary hover:-translate-y-px transition"
+                className="rounded-lg border border-(--surface-border) bg-silver-200 dark:bg-(--surface-raised) px-3 py-2 text-sm font-semibold text-primary hover:-translate-y-px transition"
               >
                 Change password
               </button>
@@ -489,7 +489,7 @@ export default function SettingsPage() {
                       type="password"
                       value={passwordForm.current}
                       onChange={(e) => setPasswordForm({ ...passwordForm, current: e.target.value })}
-                      className="rounded-lg border border-(--surface-border) bg-silver-200 dark:bg-vulcan-950 px-3 py-2 text-sm text-primary focus:border-accent-blue focus:outline-hidden"
+                      className="rounded-lg border border-(--surface-border) bg-silver-200 dark:bg-(--surface-raised) px-3 py-2 text-sm text-primary focus:border-accent-blue focus:outline-hidden"
                     />
                   </label>
                   <label className="flex flex-col gap-1 text-sm text-primary">
@@ -498,7 +498,7 @@ export default function SettingsPage() {
                       type="password"
                       value={passwordForm.next}
                       onChange={(e) => setPasswordForm({ ...passwordForm, next: e.target.value })}
-                      className="rounded-lg border border-(--surface-border) bg-silver-200 dark:bg-vulcan-950 px-3 py-2 text-sm text-primary focus:border-accent-blue focus:outline-hidden"
+                      className="rounded-lg border border-(--surface-border) bg-silver-200 dark:bg-(--surface-raised) px-3 py-2 text-sm text-primary focus:border-accent-blue focus:outline-hidden"
                     />
                   </label>
                   <label className="flex flex-col gap-1 text-sm text-primary">
@@ -507,7 +507,7 @@ export default function SettingsPage() {
                       type="password"
                       value={passwordForm.confirm}
                       onChange={(e) => setPasswordForm({ ...passwordForm, confirm: e.target.value })}
-                      className="rounded-lg border border-(--surface-border) bg-silver-200 dark:bg-vulcan-950 px-3 py-2 text-sm text-primary focus:border-accent-blue focus:outline-hidden"
+                      className="rounded-lg border border-(--surface-border) bg-silver-200 dark:bg-(--surface-raised) px-3 py-2 text-sm text-primary focus:border-accent-blue focus:outline-hidden"
                     />
                   </label>
                   <div className="flex items-center gap-2">
@@ -557,7 +557,7 @@ export default function SettingsPage() {
                       value={deleteInput}
                       onChange={(e) => setDeleteInput(e.target.value)}
                       placeholder="DELETE"
-                      className="w-full rounded-lg border border-red-300 bg-silver-200 px-2 py-2 text-sm focus:border-red-500 focus:outline-hidden dark:border-red-500/60 dark:bg-vulcan-950 dark:text-white"
+                      className="w-full rounded-lg border border-red-300 bg-silver-200 px-2 py-2 text-sm focus:border-red-500 focus:outline-hidden dark:border-red-500/60 dark:bg-(--surface-raised) dark:text-white"
                     />
                     <button
                       type="button"
@@ -591,7 +591,7 @@ export default function SettingsPage() {
           />
           {!isClosed("appearance") && (
           <div className="px-4 py-4 border-t border-(--surface-border)">
-            <div className="inline-flex items-center gap-1 rounded-xl bg-silver-200 dark:bg-vulcan-900 p-1">
+            <div className="inline-flex items-center gap-1 rounded-xl bg-silver-200 dark:bg-(--surface-card) p-1">
               {([
                 { id: "light", label: "Light", Icon: SunIcon },
                 { id: "dark",  label: "Dark",  Icon: MoonIcon },
@@ -669,7 +669,7 @@ export default function SettingsPage() {
                   onChange={(e) => setReviewMessage(e.target.value)}
                   rows={3}
                   placeholder="What’s working well? What should we improve?"
-                  className="w-full rounded-lg border border-(--surface-border) bg-silver-200 dark:bg-vulcan-950 px-3 py-2 text-sm text-primary focus:border-accent-blue focus:outline-hidden"
+                  className="w-full rounded-lg border border-(--surface-border) bg-silver-200 dark:bg-(--surface-raised) px-3 py-2 text-sm text-primary focus:border-accent-blue focus:outline-hidden"
                 />
               </label>
               <div className="flex items-center gap-2">
@@ -710,7 +710,7 @@ export default function SettingsPage() {
                 value={apiKeyName}
                 onChange={(e) => setApiKeyName(e.target.value)}
                 placeholder="Key name (e.g. OpenAI)"
-                className="flex-1 rounded-lg border border-(--surface-border) bg-silver-200 dark:bg-vulcan-950 px-3 py-2 text-sm text-primary focus:border-accent-blue focus:outline-hidden"
+                className="flex-1 rounded-lg border border-(--surface-border) bg-silver-200 dark:bg-(--surface-raised) px-3 py-2 text-sm text-primary focus:border-accent-blue focus:outline-hidden"
               />
               <button
                 type="button"
@@ -761,7 +761,7 @@ export default function SettingsPage() {
                 {Object.entries(tempSettings.apiKeys).map(([name, value]) => (
                   <div
                     key={name}
-                    className="flex items-center justify-between gap-3 rounded-xl bg-silver-200 dark:bg-vulcan-950 px-3 py-2 text-sm"
+                    className="flex items-center justify-between gap-3 rounded-xl bg-silver-200 dark:bg-(--surface-raised) px-3 py-2 text-sm"
                   >
                     <div className="flex min-w-0 flex-1 flex-col">
                       <span className="font-semibold text-primary truncate">{name}</span>
@@ -805,7 +805,7 @@ export default function SettingsPage() {
           <div className="px-4 py-4 flex flex-col gap-3 border-t border-(--surface-border)">
           <div className="flex flex-wrap items-center gap-3 pt-1">
             <select
-              className="rounded-lg border border-(--surface-border) bg-silver-200 dark:bg-vulcan-950 px-2 py-2 text-sm text-primary focus:border-accent-blue focus:outline-hidden"
+              className="rounded-lg border border-(--surface-border) bg-silver-200 dark:bg-(--surface-raised) px-2 py-2 text-sm text-primary focus:border-accent-blue focus:outline-hidden"
               value={cleanupInterval}
               onChange={(e) => setCleanupInterval(e.target.value)}
             >
@@ -845,7 +845,7 @@ export default function SettingsPage() {
               href="https://discord.gg/qeKgAKVhXa"
               target="_blank"
               rel="noreferrer"
-              className="inline-flex items-center gap-2 rounded-full bg-silver-300 dark:bg-vulcan-700 px-3 py-2 text-sm font-semibold text-primary shadow-xs hover:-translate-y-px transition"
+              className="inline-flex items-center gap-2 rounded-full bg-silver-300 dark:bg-(--surface-raised) px-3 py-2 text-sm font-semibold text-primary shadow-xs hover:-translate-y-px transition"
               aria-label="Ottegi on Discord"
             >
               <img src={discordIcon} alt="Discord logo" className="h-5 w-5 brightness-0 invert" />
@@ -854,7 +854,7 @@ export default function SettingsPage() {
               href="https://twitter.com/OttegiLLC"
               target="_blank"
               rel="noreferrer"
-              className="inline-flex items-center gap-2 rounded-full bg-silver-300 dark:bg-vulcan-700 px-3 py-2 text-sm font-semibold text-primary shadow-xs hover:-translate-y-px transition"
+              className="inline-flex items-center gap-2 rounded-full bg-silver-300 dark:bg-(--surface-raised) px-3 py-2 text-sm font-semibold text-primary shadow-xs hover:-translate-y-px transition"
               aria-label="Ottegi on X"
             >
               <img src={xIcon} alt="X logo" className="h-5 w-5 brightness-0 invert" />
@@ -863,7 +863,7 @@ export default function SettingsPage() {
               href="https://www.instagram.com/OttegiLLC"
               target="_blank"
               rel="noreferrer"
-              className="inline-flex items-center gap-2 rounded-full bg-silver-300 dark:bg-vulcan-700 px-3 py-2 text-sm font-semibold text-primary shadow-xs hover:-translate-y-px transition"
+              className="inline-flex items-center gap-2 rounded-full bg-silver-300 dark:bg-(--surface-raised) px-3 py-2 text-sm font-semibold text-primary shadow-xs hover:-translate-y-px transition"
               aria-label="Ottegi on Instagram"
             >
               <img src={instagramIcon} alt="Instagram logo" className="h-5 w-5 brightness-0 invert" />
@@ -872,7 +872,7 @@ export default function SettingsPage() {
               href="https://www.linkedin.com/company/ottegi"
               target="_blank"
               rel="noreferrer"
-              className="inline-flex items-center gap-2 rounded-full bg-silver-300 dark:bg-vulcan-700 px-3 py-2 text-sm font-semibold text-primary shadow-xs hover:-translate-y-px transition"
+              className="inline-flex items-center gap-2 rounded-full bg-silver-300 dark:bg-(--surface-raised) px-3 py-2 text-sm font-semibold text-primary shadow-xs hover:-translate-y-px transition"
               aria-label="Ottegi on LinkedIn"
             >
               <span className="text-sm font-semibold text-white">in</span>
@@ -881,7 +881,7 @@ export default function SettingsPage() {
               href="https://www.facebook.com/OttegiLLC"
               target="_blank"
               rel="noreferrer"
-              className="inline-flex items-center gap-2 rounded-full bg-silver-300 dark:bg-vulcan-700 px-3 py-2 text-sm font-semibold text-primary shadow-xs hover:-translate-y-px transition"
+              className="inline-flex items-center gap-2 rounded-full bg-silver-300 dark:bg-(--surface-raised) px-3 py-2 text-sm font-semibold text-primary shadow-xs hover:-translate-y-px transition"
               aria-label="Ottegi on Facebook"
             >
               <img src={facebookIcon} alt="Facebook logo" className="h-5 w-5 brightness-0 invert" />

--- a/packages/app/src/pages/Task.tsx
+++ b/packages/app/src/pages/Task.tsx
@@ -174,7 +174,7 @@ export default function Task() {
 
         {/* Tag filter bar — always visible on mobile, toggled on desktop */}
         {tasks.isSuccess && (
-          <div className={showFilters || hasActiveFilters ? "block" : "block md:hidden"}>
+          <div className={showFilters || hasActiveFilters ? "block" : "hidden"}>
             <TagFilterBar tasks={filteredTasks ?? []} />
           </div>
         )}

--- a/packages/app/src/pages/Task.tsx
+++ b/packages/app/src/pages/Task.tsx
@@ -9,10 +9,15 @@ import TaskInfoMenu from "@/pages/(Layout)/TaskInfoMenu";
 import { Logger } from "@/utils/logger";
 import TagFilterBar from "@/components/tasks/TagFilterBar";
 
+function capitalize(s: string) {
+  return s.replace(/\b\w/g, (ch) => ch.toUpperCase());
+}
+
 export default function Task() {
   const [appData, setAppData] = useApp();
   const [isInspecting, setIsInspecting] = useState(false);
   const [searchTerm, setSearchTerm] = useState("");
+  const [showFilters, setShowFilters] = useState(false);
 
   const tasks = useTasks();
 
@@ -25,15 +30,11 @@ export default function Task() {
 
       if (appData.activeTask.date) {
         const targetDate = new Date(appData.activeTask.date);
-        setAppData({
-          ...appData,
-          activeDate: targetDate,
-        });
+        setAppData({ ...appData, activeDate: targetDate });
       }
     }
   }, [appData, isInspecting, setAppData]);
 
-  // Close the TaskInfoMenu if the active task no longer exists (e.g., after deletion).
   useEffect(() => {
     if (!isInspecting) return;
     if (!appData.activeTask?.id) return;
@@ -76,79 +77,150 @@ export default function Task() {
     });
   }, [tasks.isSuccess, tasks.data, searchTerm]);
 
+  // Split filteredTasks into ungrouped and named groups
+  const { ungroupedTasks, taskGroups } = useMemo(() => {
+    const ungrouped: typeof filteredTasks = [];
+    const groups: Record<string, typeof filteredTasks> = {};
+
+    filteredTasks.forEach((task) => {
+      const g = (task.group ?? "").trim();
+      if (!g) {
+        ungrouped.push(task);
+      } else {
+        if (!groups[g]) groups[g] = [];
+        groups[g].push(task);
+      }
+    });
+
+    const sortedGroups = Object.entries(groups).sort(([a], [b]) => a.localeCompare(b));
+    return { ungroupedTasks: ungrouped, taskGroups: sortedGroups };
+  }, [filteredTasks]);
+
   const tasksForDay = tasks.isSuccess ? { ...tasks, data: filteredTasks } : tasks;
+  const hasActiveFilters = (appData.activeTags ?? []).length > 0;
+
+  const searchBar = (
+    <div className="flex w-full items-center gap-2 rounded-xl bg-silver-200 dark:bg-(--app-background) border border-(--surface-border) px-3 py-2 shadow-xs">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        className="h-4 w-4 shrink-0 text-slate-400"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <circle cx="11" cy="11" r="7" />
+        <line x1="16.65" y1="16.65" x2="21" y2="21" />
+      </svg>
+      <input
+        type="text"
+        value={searchTerm}
+        onChange={(e) => setSearchTerm(e.target.value)}
+        placeholder="Search tasks by title, details, or tag..."
+        className="w-full !bg-transparent text-sm text-primary outline-hidden placeholder:text-slate-400"
+      />
+      <button
+        type="button"
+        onClick={() => setShowFilters((v) => !v)}
+        aria-label="Toggle tag filters"
+        className={`shrink-0 rounded-lg p-0.5 transition ${
+          showFilters || hasActiveFilters
+            ? "text-accent-blue"
+            : "text-slate-400 hover:text-primary"
+        }`}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          className="h-4 w-4"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <line x1="4" y1="6" x2="20" y2="6" />
+          <line x1="8" y1="12" x2="16" y2="12" />
+          <line x1="11" y1="18" x2="13" y2="18" />
+        </svg>
+      </button>
+    </div>
+  );
 
   if (tasks.isLoading) {
     return (
       <div className="w-full h-full text-accent-black">
-        <div className="h-full">
-          <div className="flex flex-col items-center gap-6 px-3 md:px-6">
-            <ActiveCalendar skeleton={true} />
+        <div className="h-full pb-28 md:pb-4 flex flex-col gap-6">
+          <ActiveCalendar skeleton={true} searchSlot={searchBar} />
+          <div className="grid gap-6 md:grid-cols-2">
             <DayTasks skeleton={true} />
             <TaskContainer title="All Tasks" skeleton={true} />
           </div>
-          <div>
-            {/* <TaskInfoMenu skeleton="true" /> */}
-          </div>
         </div>
       </div>
-    )
+    );
   }
 
   return (
     <div className="w-full h-full text-accent-black">
-      <div className="h-full pb-28">
-        <div className="flex w-full justify-center">
-          <div className="flex w-full max-w-4xl flex-col items-center gap-6 px-3 md:px-6">
-            <ActiveCalendar />
-            <div className="w-full flex flex-col gap-2">
-              <div className="flex w-full items-center gap-2 rounded-xl bg-silver-200 dark:bg-[#253350] border border-(--surface-border) px-3 py-2 shadow-xs">
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  className="h-4 w-4 text-slate-400"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  aria-hidden="true"
-                >
-                  <circle cx="11" cy="11" r="7" />
-                  <line x1="16.65" y1="16.65" x2="21" y2="21" />
-                </svg>
-                <input
-                  type="text"
-                  value={searchTerm}
-                  onChange={(e) => setSearchTerm(e.target.value)}
-                  placeholder="Search tasks by title, details, or tag..."
-                  className="w-full bg-transparent text-sm text-primary outline-hidden placeholder:text-slate-400"
-                />
-              </div>
-              {tasks.isSuccess && (
-                <TagFilterBar tasks={filteredTasks ?? []} />
-              )}
-            </div>
-            <DayTasks
-              setIsInspecting={setIsInspecting}
-              tasks={tasksForDay}
-            />
-            <TaskContainer
-              identifier="all"
-              setIsInspecting={setIsInspecting}
-              title="All Tasks"
-              tasks={filteredTasks}
-              activeFilter="dailyTasks"
-            />
+      <div className="h-full pb-28 md:pb-4 flex flex-col gap-6">
+
+        {/* Full-width calendar strip with search integrated in the card */}
+        <ActiveCalendar searchSlot={searchBar} />
+
+        {/* Tag filter bar — always visible on mobile, toggled on desktop */}
+        {tasks.isSuccess && (
+          <div className={showFilters || hasActiveFilters ? "block" : "block md:hidden"}>
+            <TagFilterBar tasks={filteredTasks ?? []} />
           </div>
-        </div>
-        <div>
-          <TaskInfoMenu
-            type="edit"
-            isOpen={isInspecting}
-            setIsOpen={setIsInspecting}
+        )}
+
+        {/*
+          Desktop: unified 2-col grid.
+          Slots: [DayTasks] [All Tasks (ungrouped)] [Group1] [Group2] [Group3] …
+          Mobile: stacked single column.
+        */}
+        <div className="grid gap-6 md:grid-cols-2">
+          <DayTasks
+            setIsInspecting={setIsInspecting}
+            tasks={tasksForDay}
           />
+
+          {ungroupedTasks.length > 0 && (
+            <TaskContainer
+              identifier="ungrouped"
+              title="All Tasks"
+              tasks={ungroupedTasks}
+              setIsInspecting={setIsInspecting}
+              activeFilter="dailyTasks"
+              disableGrouping
+            />
+          )}
+
+          {taskGroups.map(([groupName, groupTasks]) => (
+            <TaskContainer
+              key={groupName}
+              identifier={`group-${groupName}`}
+              title={capitalize(groupName)}
+              tasks={groupTasks}
+              setIsInspecting={setIsInspecting}
+              activeFilter="dailyTasks"
+              disableGrouping
+            />
+          ))}
         </div>
+      </div>
+
+      <div>
+        <TaskInfoMenu
+          type="edit"
+          isOpen={isInspecting}
+          setIsOpen={setIsInspecting}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
UI overhaul: calendar redesign, home refresh, custom date picker

Calendar

- Desktop week view: columns now fill the full page height; task areas scroll independently per column; priority shown as ! marks in the top-right corner of each card
- Desktop month view: today's date gets a ring only (no full-cell background); task pills use a consistent style
- Mobile week view: replaced 7 large cards with a compact single-list layout (day label + date + task count badge + task titles inline)
- Mobile month view: full viewport width and height using -ml-7 w-screen breakout; task pill count is dynamic & driven by window.innerHeight and number of week rows so it fills cells correctly on any device size; week rows are equal-height via CSS grid 1fr (fixes last-row height inconsistency); + x more overflow label is pinned to the bottom of each cell

Home

- Desktop header: greeting left-aligned, date right-aligned
- Mobile hero banner: "Hello [Name]!" and date on the same line, same size, vertically centered; removed "Today" label and date link pill
- Renamed Announcements & Notes; added localStorage-persisted personal notes with desktop-only add form (Cmd/Ctrl+Enter to save) and hover-reveal delete; removed empty state copy
- Removed all "Live Sync" badges

Task list

- Tasks render in a single row: title truncates, date is whitespace-nowrap, tags hidden from preview, priority as rightmost element

Edit task menu

- Replaced both <input type="datetime-local"> and <input type="date"> with a custom DateTimePicker & month calendar grid with floating portal overlay (doesn't push form content), hour/minute inputs, AM/PM toggle; date-only mode auto-closes on day pick
- Tag editor: fixed dark mode contrast

Bug fixes

- Removed a stray unlayered .hidden { display: none } rule in index.css that was overriding md:grid / md:flex and making the desktop calendar invisible
- overflow-y-auto on the calendar tasks wrapper was implicitly clipping overflow-x, chopping the full-width mobile month grid & fixed by removing it (column-level scroll handles desktop)